### PR TITLE
fix: http request body = inline call

### DIFF
--- a/src/language/syntax/rules/map/map.ts
+++ b/src/language/syntax/rules/map/map.ts
@@ -333,7 +333,7 @@ const HTTP_CALL_STATEMENT_REQUEST_BODY_SLOT = SyntaxRule.identifier(
 ).followedBy(
   SyntaxRule.sameLine(OBJECT_LITERAL).or(
     SyntaxRule.operator('=')
-      .followedBy(RHS_EXPRESSION_FACTORY('\n', '}'))
+      .followedBy(INLINE_CALL.or(RHS_EXPRESSION_FACTORY('\n', '}')))
       .map(([_op, value]) => value)
   )
 );


### PR DESCRIPTION
small fix which allows
```
http GET "url" {
    request {
        body = call Op()
    }
}
```

I see no reason to not allow this since it's just a shorter way of doing:
```
set {
    body = call Op()
}
http GET "url" {
    request {
        body = body
    }
}
```