### PR TITLE
fix: documentation extraction newline handling

### DIFF
--- a/src/language/language.test.ts
+++ b/src/language/language.test.ts
@@ -132,6 +132,10 @@ describe('profile', () => {
       seen
     }
     
+    "
+    Title of the field channel
+    Description of the field channel
+    "
     field channel enum {
       sms
       whatsapp
@@ -307,6 +311,8 @@ describe('profile', () => {
               },
             ],
           },
+          title: 'Title of the field channel',
+          description: 'Description of the field channel',
         },
       ],
     });

--- a/src/language/syntax/util.test.ts
+++ b/src/language/syntax/util.test.ts
@@ -17,12 +17,23 @@ describe('extract documentation', () => {
     });
   });
 
-  it('should extract title and description from multiline', () => {
+  it('should extract title and description from multiline with whitespace trimming', () => {
     const title = 'This is the title, it does not contain newlines';
     const description =
       'This is \n the description, it does \n contain \n some newlines';
     expect(
-      extractDocumentation(title + '\n' + '  \t\n' + description)
+      extractDocumentation(' ' + title + ' \t\n' + '  \t\n' + description)
+    ).toStrictEqual({
+      title,
+      description,
+    });
+  });
+
+  it('should extract title and description from multiline with empty leading newlines', () => {
+    const title = 'Title';
+    const description = 'Description';
+    expect(
+      extractDocumentation('\n' + title + '\n' + description)
     ).toStrictEqual({
       title,
       description,

--- a/src/language/syntax/util.ts
+++ b/src/language/syntax/util.ts
@@ -122,9 +122,10 @@ export function extractDocumentation(
 
   const title = lines[firstNonemptyLineIndex].trim();
 
-  const descriptionStart = lines
-    .slice(0, firstNonemptyLineIndex + 1)
-    .reduce((acc, curr) => (acc += curr.length), 0);
+  const descriptionStart =
+    lines
+      .slice(0, firstNonemptyLineIndex + 1)
+      .reduce((acc, curr) => (acc += curr.length), 0) + firstNonemptyLineIndex;
   const description = input.slice(descriptionStart).trim();
 
   if (description !== '') {


### PR DESCRIPTION
Hopefully this string handling mess is ok now. Over these last few bugs the tests have gotten more robust so they should catch any regressions more reliably now.