### PR TITLE
chore: fix README links pointing to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parser
 
-<img src="https://github.com/superfaceai/parser/blob/master/docs/LogoGreen.png" alt="superface logo" width="150" height="150">
+<img src="https://github.com/superfaceai/parser/blob/main/docs/LogoGreen.png" alt="superface logo" width="150" height="150">
 
 Superface Parser compiles Superface profiles and maps into representation that can be interpreter using the Superface SDK.
 
@@ -57,7 +57,7 @@ console.log(inspect(result));
 
 Superface is not man-in-the-middle so it does not require any access to secrets that are needed to communicate with provider API. Superface CLI only prepares super.json file with authorization fields in form of environment variable. You just set correct variables and communicate directly with provider API.
 
-You can find more information in [SDK repository](https://github.com/superfaceai/sdk-js/blob/master/SECURITY.md).
+You can find more information in [SDK repository](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md).
 
 ## Support
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
Fix links pointing to master in README

## Motivation and Context
Master was renamed to main.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
