### PR TITLE
fix: spans and locations of lexer syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,184 +7,170 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.18-beta.0] - 2021-06-07
 ### Added
-* Added an explicit hint to ShorthandPropertyAssignment Jessie construct error
+- Added an explicit hint to ShorthandPropertyAssignment Jessie construct error
 
 ### Changed
-* Changed how MatchAttemts merge works to preserve expected behavior
+- Changed how MatchAttemts merge works to preserve expected behavior
 
 ### Fixed
-* Fixed Jessie errors (and other lexer errors) not reporting correct location
+- Fixed Jessie errors (and other lexer errors) not reporting correct location
 
 ## [0.0.17] - 2021-05-04
-
 ### Added
-* Added support for returning multiple errors from Lexer parsing
+- Added support for returning multiple errors from Lexer parsing
 
 ### Changed
-* Changed internal handling of persing errors and result types
-* Better generics for Lexer interface
+- Changed internal handling of persing errors and result types
+- Better generics for Lexer interface
 
 ### Fixed
-* Fixed template string RHS parsing
-* Fixed jessie transpilation when polyfill is generated
+- Fixed template string RHS parsing
+- Fixed jessie transpilation when polyfill is generated
 
 ## [0.0.16] - 2021-04-26
-
 ### Added
-* Automatic feature parsing from environment variables
+- Automatic feature parsing from environment variables
 
 ### Changed
-* Renamed `checkKeywordLiteral` to `tryKeywordLiteral`
-* Removed unused `countStartingWithNewlines`
+- Renamed `checkKeywordLiteral` to `tryKeywordLiteral`
+- Removed unused `countStartingWithNewlines`
 
 ### Fixed
-* Fixed error produced by `countStartingNumbersRadix` to use string template
+- Fixed error produced by `countStartingNumbersRadix` to use string template
 
 ## [0.0.15] - 2021-03-23
-
 ### Added
-* VERSION constant export
-* `multiple_security_requirements` parser feature
+- VERSION constant export
+- `multiple_security_requirements` parser feature
 
 ### Changed
-* Map security requirements syntax
+- Map security requirements syntax
 
 ## [0.0.14] - 2021-02-04
-
 ### Added
-* `call foreach` map rule
+- `call foreach` map rule
 
 ### Changed
-* Map validator uses `MapAstVisitor` from ast package
-* Profile io validator uses `ProfileAstVisitor` from ast package
-* Map security requirements syntax
-* Updated ast dependency to `v0.0.22`
+- Map validator uses `MapAstVisitor` from ast package
+- Profile io validator uses `ProfileAstVisitor` from ast package
+- Map security requirements syntax
+- Updated ast dependency to `v0.0.22`
 
 ### Fixed
-* Allow enum inside list in Profile IO Analyzer
-* Map validator version error reporting with new version nodes
+- Allow enum inside list in Profile IO Analyzer
+- Map validator version error reporting with new version nodes
 
 ## [0.0.11] - 2021-01-19
-
 ### Added
-* Public `parseDocumentId` for partial parsing
+- Public `parseDocumentId` for partial parsing
 
 ### Changed
-* Interfaces for map and profile id
-* Improved document id version parsing
-* Rename `isLowercaseIdentifier` to `isValidDocumentIdentifier`
+- Interfaces for map and profile id
+- Improved document id version parsing
+- Rename `isLowercaseIdentifier` to `isValidDocumentIdentifier`
 
 ### Fixed
-* Document id `parseProfileId` not returning version label
+- Document id `parseProfileId` not returning version label
 
 ## [0.0.11] - 2021-01-19
-
 ### Added
-* Profile IO Analyzer that generates profile structure
-* Map Validator for validating profile input/output components 
-* Interface for using Profile IO Analyzer and Map Validator
-* Interface for composing error and warning messages
-* Profile structure interfaces
-* Profile structure utils
-* ValidationIssue interface
+- Profile IO Analyzer that generates profile structure
+- Map Validator for validating profile input/output components
+- Interface for using Profile IO Analyzer and Map Validator
+- Interface for composing error and warning messages
+- Profile structure interfaces
+- Profile structure utils
+- ValidationIssue interface
 
 ## [0.0.10] - 2021-01-11
-
 ### Changed
-* Exported `parseVersion`, `parseProfileId` and `parseMapId` publicly
-* Changed ast dependency to `v0.0.20`
+- Exported `parseVersion`, `parseProfileId` and `parseMapId` publicly
+- Changed ast dependency to `v0.0.20`
 
 ### Fixed
-* Fixed `ID_NAME_RE` to not accept leading `_` or `-`
+- Fixed `ID_NAME_RE` to not accept leading `_` or `-`
 
 ## [0.0.9] - 2021-01-09
-
 ### Fixed
-* Fixed the weird behavior of `String.prototype.split(string, number)` by implementing a custom `splitLimit` function.
+- Fixed the weird behavior of `String.prototype.split(string, number)` by implementing a custom `splitLimit` function.
 
 ## [0.0.8] - 2021-01-09
-
 ### Fixed
-* Fixed semver parsing allowing invalid version strings like `1.x1`
+- Fixed semver parsing allowing invalid version strings like `1.x1`
 
 ## [0.0.7] - 2021-01-09
-
 ### Added
-* Document id and version parsing implementation
-* Profile `version` header field
-* Map `variant` header field
+- Document id and version parsing implementation
+- Profile `version` header field
+- Map `variant` header field
 
 ### Changed
-* Refactored `computeEndLocation` to be externally reusable
-* Profile `profile = <string>` syntax to `name = '[<scope>/]<name>`
-* Map `profile = <string>` syntax to `profile = [<scope>/]<name>@<version>`
-* Moved test files from `examples` folder to `fixtures` folder
+- Refactored `computeEndLocation` to be externally reusable
+- Profile `profile = <string>` syntax to `name = '[<scope>/]<name>`
+- Map `profile = <string>` syntax to `profile = [<scope>/]<name>@<version>`
+- Moved test files from `examples` folder to `fixtures` folder
 
 ### Fixed
-* Some typos in comments and descriptions
+- Some typos in comments and descriptions
 
 ## [0.0.6] - 2020-11-30
-
 ### Changed
-* Package renamed from `superface-parser` to `parser`
+- Package renamed from `superface-parser` to `parser`
 
 ## [0.0.5] - 2020-11-25
-
 ### Added
-* `none` security scheme for http call
-* Inline call support in maps
+- `none` security scheme for http call
+- Inline call support in maps
 
 ### Changed
-* Scope renamed from `@superindustries` to `@superfaceai`
+- Scope renamed from `@superindustries` to `@superfaceai`
 
-## [v0.0.4-beta3] - 2020-10-26
-
+## [0.0.4-beta3] - 2020-10-26
 ### Added
-* `SyntaxError` category
-* `LexerContext` to communicate context from parser to the lexer
-* `LexerTokenStream` with native save and rollback
-* Lexer unknown token
-* Jessie expression lexer context terminator characters
-* Newline lexer token and parser rules
-* Parser features (`nested_object_literals` and `shorthand_http_request_slots`)
-* Map parser rules
-* `PeekUnknown` and `AndThen` syntax rules
-* Simple build option that skips parcel because of bugs with the produced artifacts
+- `SyntaxError` category
+- `LexerContext` to communicate context from parser to the lexer
+- `LexerTokenStream` with native save and rollback
+- Lexer unknown token
+- Jessie expression lexer context terminator characters
+- Newline lexer token and parser rules
+- Parser features (`nested_object_literals` and `shorthand_http_request_slots`)
+- Map parser rules
+- `PeekUnknown` and `AndThen` syntax rules
+- Simple build option that skips parcel because of bugs with the produced artifacts
 
 ### Changed
-* Updated dependency versions
-* Updated typescript to version 4+ and using new features
-* Line comment token from `#` to `//`
+- Updated dependency versions
+- Updated typescript to version 4+ and using new features
+- Line comment token from `#` to `//`
 
 ### Removed
-* `+` and `-` operators
+- `+` and `-` operators
 
 ### Fixed
-* Jessie expression lexer context handling string templates
-* Lexer parsing numbers with `+` and `-` prefixes
+- Jessie expression lexer context handling string templates
+- Lexer parsing numbers with `+` and `-` prefixes
 
 ## [0.0.3] - 2020-08-26
-
 ### Removed
-* Dependency on superface sdk
+- Dependency on superface sdk
 
-## [0.0.2] - 2020-08-25
-
+## 0.0.2 - 2020-08-25
 ### Added
-* Parcel build system
+- Parcel build system
 
 ### Changed
-* Documentation extraction from doc strings
-* Usecase result parsing as optional
+- Documentation extraction from doc strings
+- Usecase result parsing as optional
 
-[Unreleased]: https://github.com/superfaceai/parser/compare/v0.0.17...HEAD
+[Unreleased]: https://github.com/superfaceai/parser/compare/v0.0.18-beta.0...HEAD
+[0.0.18-beta.0]: https://github.com/superfaceai/parser/compare/v0.0.17...v0.0.18-beta.0
 [0.0.17]: https://github.com/superfaceai/parser/compare/v0.0.16...v0.0.17
 [0.0.16]: https://github.com/superfaceai/parser/compare/v0.0.15...v0.0.16
 [0.0.15]: https://github.com/superfaceai/parser/compare/v0.0.14...v0.0.15
-[0.0.14]: https://github.com/superfaceai/parser/compare/v0.0.13...v0.0.14
-[0.0.13]: https://github.com/superfaceai/parser/compare/v0.0.12...v0.0.13
-[0.0.12]: https://github.com/superfaceai/parser/compare/v0.0.11...v0.0.12
+[0.0.14]: https://github.com/superfaceai/parser/compare/v0.0.11...v0.0.14
+[0.0.11]: https://github.com/superfaceai/parser/compare/v0.0.11...v0.0.11
 [0.0.11]: https://github.com/superfaceai/parser/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/superfaceai/parser/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/superfaceai/parser/compare/v0.0.8...v0.0.9
@@ -192,6 +178,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.7]: https://github.com/superfaceai/parser/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/superfaceai/parser/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/superfaceai/parser/compare/v0.0.4-beta3...v0.0.5
-[v0.0.4-beta3]: https://github.com/superfaceai/parser/compare/v0.0.3...v0.0.4-beta3
+[0.0.4-beta3]: https://github.com/superfaceai/parser/compare/v0.0.3...v0.0.4-beta3
 [0.0.3]: https://github.com/superfaceai/parser/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/superfaceai/parser/releases/tag/v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Added
+* Added an explicit hint to ShorthandPropertyAssignment Jessie construct error
+
+### Changed
+* Changed how MatchAttemts merge works to preserve expected behavior
+
+### Fixed
+* Fixed Jessie errors (and other lexer errors) not reporting correct location
+
 ## [0.0.17] - 2021-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,8 @@
 * Documentation extraction from doc strings
 * Usecase result parsing as optional
 
-[Unreleased]: https://github.com/superfaceai/parser/compare/v0.0.16...HEAD
+[Unreleased]: https://github.com/superfaceai/parser/compare/v0.0.17...HEAD
+[0.0.17]: https://github.com/superfaceai/parser/compare/v0.0.16...v0.0.17
 [0.0.16]: https://github.com/superfaceai/parser/compare/v0.0.15...v0.0.16
 [0.0.15]: https://github.com/superfaceai/parser/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/superfaceai/parser/compare/v0.0.13...v0.0.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/parser",
-  "version": "0.0.17",
+  "version": "0.0.18-beta.0",
   "description": "Level 5 autonomous, self-driving API client, https://superface.ai",
   "repository": "https://github.com/superfaceai/parser.git",
   "source": "lib/index.js",

--- a/src/language/jessie/validator/constructs.ts
+++ b/src/language/jessie/validator/constructs.ts
@@ -34,7 +34,9 @@ export const FORBIDDEN_CONSTRUCTS: {
       hint: (source: string, node: ts.FunctionDeclaration): string => {
         let name;
         if (node.name) {
-          name = source.substring(node.name.pos, node.name.end).trim();
+          name = source
+            .substring(node.name.getStart(), node.name.getEnd())
+            .trim();
         } else {
           name = 'anon';
         }
@@ -50,9 +52,11 @@ export const FORBIDDEN_CONSTRUCTS: {
     {
       hint: (source: string, node: ts.BinaryOperatorToken): string => {
         const parent = node.parent as ts.BinaryExpression;
-        const left = source.substring(parent.left.pos, parent.left.end).trim();
+        const left = source
+          .substring(parent.left.getStart(), parent.left.getEnd())
+          .trim();
         const right = source
-          .substring(parent.right.pos, parent.right.end)
+          .substring(parent.right.getStart(), parent.right.getEnd())
           .trim();
 
         return `Use \`${left} === ${right}\` instead`;
@@ -63,9 +67,11 @@ export const FORBIDDEN_CONSTRUCTS: {
     {
       hint: (source: string, node: ts.BinaryOperatorToken): string => {
         const parent = node.parent as ts.BinaryExpression;
-        const left = source.substring(parent.left.pos, parent.left.end).trim();
+        const left = source
+          .substring(parent.left.getStart(), parent.left.getEnd())
+          .trim();
         const right = source
-          .substring(parent.right.pos, parent.right.end)
+          .substring(parent.right.getStart(), parent.right.getEnd())
           .trim();
 
         return `Use \`${left} !== ${right}\` instead`;
@@ -78,7 +84,7 @@ export const FORBIDDEN_CONSTRUCTS: {
         node.operator === ts.SyntaxKind.PlusPlusToken,
       hint: (source: string, node: ts.PrefixUnaryExpression): string => {
         const operand = source
-          .substring(node.operand.pos, node.operand.end)
+          .substring(node.operand.getStart(), node.operand.getEnd())
           .trim();
 
         return `Use \`${operand} += 1\` or \`${operand}++\` instead`;
@@ -89,10 +95,29 @@ export const FORBIDDEN_CONSTRUCTS: {
         node.operator === ts.SyntaxKind.MinusMinusToken,
       hint: (source: string, node: ts.PrefixUnaryExpression): string => {
         const operand = source
-          .substring(node.operand.pos, node.operand.end)
+          .substring(node.operand.getStart(), node.operand.getEnd())
           .trim();
 
         return `Use \`${operand} -= 1\` or \`${operand}--\` instead`;
+      },
+    },
+  ],
+  [ts.SyntaxKind.ShorthandPropertyAssignment]: [
+    {
+      hint: (source: string, node: ts.ShorthandPropertyAssignment): string => {
+        const beforeText = source.substring(
+          node.parent.getStart(),
+          node.name.getStart()
+        );
+        const afterText = source.substring(
+          node.name.getEnd(),
+          node.parent.getEnd()
+        );
+        const propertyName = source
+          .substring(node.name.getStart(), node.name.getEnd())
+          .trim();
+
+        return `Use \`${beforeText}${propertyName}: ${propertyName}${afterText}\` instead`;
       },
     },
   ],

--- a/src/language/jessie/validator/validator.test.ts
+++ b/src/language/jessie/validator/validator.test.ts
@@ -245,45 +245,22 @@ describe('validator', () => {
     ])('Valid scripts: %s', (_name, script) => {
       expect(script).toBeValidScript();
     });
-  });
-  describe('constructDebugVisualTree', () => {
-    let consoleDebugSpy: jest.SpyInstance;
-    const originalLogLevel = process.env.LOG_LEVEL;
 
-    beforeAll(() => {
-      process.env.LOG_LEVEL = 'debug';
-    });
+    it('returns correct error', () => {
+      const script = 'Object.keys(something).map(name => ({ name, foo: foo }))';
 
-    afterAll(() => {
-      process.env.LOG_LEVEL = originalLogLevel;
-    });
+      const errors = validateScript(script);
 
-    beforeEach(() => {
-      consoleDebugSpy = jest
-        .spyOn(console, 'debug')
-        .mockImplementation(() => undefined);
-    });
-
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-
-    it('constructs debug tree from empty statement', () => {
-      validateScript(';');
-
-      expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
-      expect(consoleDebugSpy).toHaveBeenCalledWith(
-        'NODE SourceFile ";"\n\tNODE EmptyStatement ";" [S]\n\tNODE EndOfFileToken ""\n'
-      );
-    });
-
-    it('constructs debug tree from non strict equality', () => {
-      validateScript('1 == 1 && 1 != 2');
-
-      expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
-      expect(consoleDebugSpy).toHaveBeenCalledWith(
-        'NODE SourceFile "1 == 1 && 1 != 2"\n\tNODE ExpressionStatement "1 == 1 && 1 != 2"\n\t\tNODE BinaryExpression "1 == 1 && 1 != 2"\n\t\t\tNODE BinaryExpression "1 == 1"\n\t\t\t\tNODE FirstLiteralToken "1"\n\t\t\t\tNODE EqualsEqualsToken "==" [R]\n\t\t\t\tNODE FirstLiteralToken "1"\n\t\t\tNODE AmpersandAmpersandToken "&&"\n\t\t\tNODE BinaryExpression "1 != 2"\n\t\t\t\tNODE FirstLiteralToken "1"\n\t\t\t\tNODE ExclamationEqualsToken "!=" [R]\n\t\t\t\tNODE FirstLiteralToken "2"\n\tNODE EndOfFileToken ""\n'
-      );
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toStrictEqual({
+        category: 'Jessie validation',
+        detail: 'ShorthandPropertyAssignment construct is not supported',
+        hint: 'Use `{ name: name, foo: foo }` instead',
+        relativeSpan: {
+          start: 38,
+          end: 42,
+        },
+      });
     });
   });
 });

--- a/src/language/language.test.ts
+++ b/src/language/language.test.ts
@@ -2,7 +2,12 @@ import fs from 'fs';
 import { join } from 'path';
 
 import { Source } from './source';
-import { parseMap, parseProfile, parseRule } from './syntax/parser';
+import {
+  parseMap,
+  parseProfile,
+  parseRule,
+  parseRuleResult,
+} from './syntax/parser';
 import { SyntaxRule } from './syntax/rule';
 import * as map from './syntax/rules/map';
 import { profile as profileRules } from './syntax/rules/profile';
@@ -576,6 +581,31 @@ describe('map strict', () => {
           },
         },
       ]);
+    });
+
+    it('should error with correct span with error in jessie', () => {
+      const input = `{
+        foo = 1
+        bar   =   Object.keys(t).map(name => ({   name, foo: foo }))
+      }`;
+
+      const source = new Source(input);
+
+      const result = parseRuleResult(map.OBJECT_LITERAL, source, true);
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'success') {
+        throw 'unreachable';
+      }
+
+      expect(result.error.span).toStrictEqual({
+        start: 68,
+        end: 72,
+      });
+      expect(result.error.location).toStrictEqual({
+        line: 3,
+        column: 51,
+      });
     });
   });
 

--- a/src/language/lexer/lexer.test.ts
+++ b/src/language/lexer/lexer.test.ts
@@ -1,4 +1,4 @@
-import { Source } from '../source';
+import { Location, Source, Span } from '../source';
 import { LexerContext, LexerContextType } from './context';
 import { DEFAULT_TOKEN_KIND_FILTER, Lexer } from './lexer';
 import {
@@ -866,6 +866,96 @@ ng2"
           terminationTokens: ['}'],
         })
       ).toReturnError('FunctionExpression construct is not supported');
+    });
+  });
+
+  describe('metadata', () => {
+    it('should yield correct span for tokens', () => {
+      const lexer = new Lexer(
+        new Source(
+          `the tokens
+          and their spans // some comments
+          and 1 number`
+        ),
+        {
+          [LexerTokenKind.COMMENT]: false,
+          [LexerTokenKind.NEWLINE]: false,
+          [LexerTokenKind.IDENTIFIER]: false,
+          [LexerTokenKind.LITERAL]: false,
+          [LexerTokenKind.OPERATOR]: false,
+          [LexerTokenKind.SEPARATOR]: false,
+          [LexerTokenKind.STRING]: false,
+          [LexerTokenKind.JESSIE_SCRIPT]: false,
+          [LexerTokenKind.UNKNOWN]: false,
+        }
+      );
+
+      const expected: Span[] = [
+        { start: 0, end: 0 }, // SOF
+        { start: 0, end: 3 }, // the
+        { start: 4, end: 10 }, // tokens
+        { start: 10, end: 11 }, // newline
+        { start: 21, end: 24 }, // and
+        { start: 25, end: 30 }, // their
+        { start: 31, end: 36 }, // spans
+        { start: 37, end: 53 }, // comment
+        { start: 53, end: 54 }, // newline
+        { start: 64, end: 67 }, // and
+        { start: 68, end: 69 }, // 1
+        { start: 70, end: 76 }, // number
+        { start: 76, end: 76 }, // EOF
+      ];
+
+      const actual = [];
+      for (let i = 0; i < expected.length; i += 1) {
+        actual.push(lexer.advance().span);
+      }
+
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('should yield correct location for tokens', () => {
+      const lexer = new Lexer(
+        new Source(
+          `the tokens
+          and their spans // some comments
+          and 1 number`
+        ),
+        {
+          [LexerTokenKind.COMMENT]: false,
+          [LexerTokenKind.NEWLINE]: false,
+          [LexerTokenKind.IDENTIFIER]: false,
+          [LexerTokenKind.LITERAL]: false,
+          [LexerTokenKind.OPERATOR]: false,
+          [LexerTokenKind.SEPARATOR]: false,
+          [LexerTokenKind.STRING]: false,
+          [LexerTokenKind.JESSIE_SCRIPT]: false,
+          [LexerTokenKind.UNKNOWN]: false,
+        }
+      );
+
+      const expected: Location[] = [
+        { line: 1, column: 1 }, // SOF
+        { line: 1, column: 1 }, // the
+        { line: 1, column: 5 }, // tokens
+        { line: 1, column: 11 }, // newline
+        { line: 2, column: 11 }, // and
+        { line: 2, column: 15 }, // their
+        { line: 2, column: 21 }, // spans
+        { line: 2, column: 27 }, // comment
+        { line: 2, column: 43 }, // newline
+        { line: 3, column: 11 }, // and
+        { line: 3, column: 15 }, // 1
+        { line: 3, column: 17 }, // number
+        { line: 3, column: 23 }, // EOF
+      ];
+
+      const actual = [];
+      for (let i = 0; i < expected.length; i += 1) {
+        actual.push(lexer.advance().location);
+      }
+
+      expect(actual).toStrictEqual(expected);
     });
   });
 

--- a/src/language/syntax/rule.ts
+++ b/src/language/syntax/rule.ts
@@ -43,22 +43,34 @@ export class MatchAttempts {
       return this;
     }
 
-    // Both equal or both undefined
-    if (this.token?.span.start === other.token?.span.start) {
-      // merge
+    // resolve undefined
+    if (this.token === undefined && other.token === undefined) {
       return new MatchAttempts(this.token, [...this.rules, ...other.rules]);
     }
-
     // undefined is treated as greater than defined
     if (this.token === undefined) {
       return this;
-    } else if (
-      other.token === undefined ||
-      other.token.span.start > this.token.span.start
-    ) {
+    } else if (other.token === undefined) {
       return other;
-    } else {
+    }
+
+    // if the tokens are of UNKNOWN variant then we compare their error spans instead
+    const thisSpan =
+      this.token.data.kind === LexerTokenKind.UNKNOWN
+        ? this.token.data.error.span
+        : this.token.span;
+    const otherSpan =
+      other.token.data.kind === LexerTokenKind.UNKNOWN
+        ? other.token.data.error.span
+        : other.token.span;
+
+    if (thisSpan.start === otherSpan.start) {
+      return new MatchAttempts(this.token, [...this.rules, ...other.rules]);
+    }
+    if (thisSpan.start > otherSpan.start) {
       return this;
+    } else {
+      return other;
     }
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
Fixes how Lexer computes and assigns location and span metadata to tokens and errors so that jessie errors are correctly reported

## Motivation and Context
The error reporting for jessie script lexing was lacking, now it should be better

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
