### PR TITLE
feat: extract formatIssueContext function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Extracted `formatIssueContext` function
+
 ## [0.0.20] - 2021-08-03
 
 ## [0.0.20-beta.0] - 2021-08-03

--- a/src/interpreter/utils.test.ts
+++ b/src/interpreter/utils.test.ts
@@ -1,4 +1,9 @@
-import { CallStatementNode, HttpCallStatementNode, OutcomeStatementNode, SetStatementNode } from '@superfaceai/ast';
+import {
+  CallStatementNode,
+  HttpCallStatementNode,
+  OutcomeStatementNode,
+  SetStatementNode,
+} from '@superfaceai/ast';
 
 import { getOutcomes } from './utils';
 
@@ -8,26 +13,26 @@ describe('getOutcomes', () => {
       kind: 'OutcomeStatement',
       isError: true,
       terminateFlow: false,
-      value: { kind: 'PrimitiveLiteral', value: 1 }
+      value: { kind: 'PrimitiveLiteral', value: 1 },
     },
     {
       kind: 'OutcomeStatement',
       isError: false,
       terminateFlow: false,
-      value: { kind: 'PrimitiveLiteral', value: 2 }
+      value: { kind: 'PrimitiveLiteral', value: 2 },
     },
     {
       kind: 'OutcomeStatement',
       isError: true,
       terminateFlow: false,
-      value: { kind: 'PrimitiveLiteral', value: 3 }
+      value: { kind: 'PrimitiveLiteral', value: 3 },
     },
     {
       kind: 'OutcomeStatement',
       isError: false,
       terminateFlow: false,
-      value: { kind: 'PrimitiveLiteral', value: 4 }
-    }
+      value: { kind: 'PrimitiveLiteral', value: 4 },
+    },
   ];
   const NESTED: [HttpCallStatementNode, CallStatementNode] = [
     {
@@ -37,42 +42,30 @@ describe('getOutcomes', () => {
       responseHandlers: [
         {
           kind: 'HttpResponseHandler',
-          statements: [
-            OUTCOMES[2]
-          ]
-        }
-      ]
+          statements: [OUTCOMES[2]],
+        },
+      ],
     },
     {
       kind: 'CallStatement',
       operationName: 'op',
       arguments: [],
-      statements: [
-        OUTCOMES[3]
-      ]
-    }
+      statements: [OUTCOMES[3]],
+    },
   ];
   const OTHER: SetStatementNode = {
     kind: 'SetStatement',
-    assignments: []
+    assignments: [],
   };
 
   it('returns all outcomes', () => {
-    const outcomes = getOutcomes(
-      {
-        kind: 'MapDefinition',
-        name: 'd',
-        usecaseName: 'd',
-        statements: [
-          OUTCOMES[0],
-          OUTCOMES[1],
-          NESTED[0],
-          NESTED[1],
-          OTHER
-        ]
-      }
-    );
-    
+    const outcomes = getOutcomes({
+      kind: 'MapDefinition',
+      name: 'd',
+      usecaseName: 'd',
+      statements: [OUTCOMES[0], OUTCOMES[1], NESTED[0], NESTED[1], OTHER],
+    });
+
     expect(outcomes).toHaveLength(4);
     expect(outcomes).toContain(OUTCOMES[0]);
     expect(outcomes).toContain(OUTCOMES[1]);
@@ -86,17 +79,11 @@ describe('getOutcomes', () => {
         kind: 'MapDefinition',
         name: 'd',
         usecaseName: 'd',
-        statements: [
-          OUTCOMES[0],
-          OUTCOMES[1],
-          NESTED[0],
-          NESTED[1],
-          OTHER
-        ]
+        statements: [OUTCOMES[0], OUTCOMES[1], NESTED[0], NESTED[1], OTHER],
       },
       true
     );
-    
+
     expect(outcomes).toHaveLength(2);
     expect(outcomes).toContain(OUTCOMES[0]);
     expect(outcomes).toContain(OUTCOMES[2]);
@@ -108,17 +95,11 @@ describe('getOutcomes', () => {
         kind: 'MapDefinition',
         name: 'd',
         usecaseName: 'd',
-        statements: [
-          OUTCOMES[0],
-          OUTCOMES[1],
-          NESTED[0],
-          NESTED[1],
-          OTHER
-        ]
+        statements: [OUTCOMES[0], OUTCOMES[1], NESTED[0], NESTED[1], OTHER],
       },
       false
     );
-    
+
     expect(outcomes).toHaveLength(2);
     expect(outcomes).toContain(OUTCOMES[1]);
     expect(outcomes).toContain(OUTCOMES[3]);

--- a/src/interpreter/utils.test.ts
+++ b/src/interpreter/utils.test.ts
@@ -1,0 +1,126 @@
+import { CallStatementNode, HttpCallStatementNode, OutcomeStatementNode, SetStatementNode } from '@superfaceai/ast';
+
+import { getOutcomes } from './utils';
+
+describe('getOutcomes', () => {
+  const OUTCOMES: OutcomeStatementNode[] = [
+    {
+      kind: 'OutcomeStatement',
+      isError: true,
+      terminateFlow: false,
+      value: { kind: 'PrimitiveLiteral', value: 1 }
+    },
+    {
+      kind: 'OutcomeStatement',
+      isError: false,
+      terminateFlow: false,
+      value: { kind: 'PrimitiveLiteral', value: 2 }
+    },
+    {
+      kind: 'OutcomeStatement',
+      isError: true,
+      terminateFlow: false,
+      value: { kind: 'PrimitiveLiteral', value: 3 }
+    },
+    {
+      kind: 'OutcomeStatement',
+      isError: false,
+      terminateFlow: false,
+      value: { kind: 'PrimitiveLiteral', value: 4 }
+    }
+  ];
+  const NESTED: [HttpCallStatementNode, CallStatementNode] = [
+    {
+      kind: 'HttpCallStatement',
+      method: 'GET',
+      url: '',
+      responseHandlers: [
+        {
+          kind: 'HttpResponseHandler',
+          statements: [
+            OUTCOMES[2]
+          ]
+        }
+      ]
+    },
+    {
+      kind: 'CallStatement',
+      operationName: 'op',
+      arguments: [],
+      statements: [
+        OUTCOMES[3]
+      ]
+    }
+  ];
+  const OTHER: SetStatementNode = {
+    kind: 'SetStatement',
+    assignments: []
+  };
+
+  it('returns all outcomes', () => {
+    const outcomes = getOutcomes(
+      {
+        kind: 'MapDefinition',
+        name: 'd',
+        usecaseName: 'd',
+        statements: [
+          OUTCOMES[0],
+          OUTCOMES[1],
+          NESTED[0],
+          NESTED[1],
+          OTHER
+        ]
+      }
+    );
+    
+    expect(outcomes).toHaveLength(4);
+    expect(outcomes).toContain(OUTCOMES[0]);
+    expect(outcomes).toContain(OUTCOMES[1]);
+    expect(outcomes).toContain(OUTCOMES[2]);
+    expect(outcomes).toContain(OUTCOMES[3]);
+  });
+
+  it('returns error outcomes', () => {
+    const outcomes = getOutcomes(
+      {
+        kind: 'MapDefinition',
+        name: 'd',
+        usecaseName: 'd',
+        statements: [
+          OUTCOMES[0],
+          OUTCOMES[1],
+          NESTED[0],
+          NESTED[1],
+          OTHER
+        ]
+      },
+      true
+    );
+    
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes).toContain(OUTCOMES[0]);
+    expect(outcomes).toContain(OUTCOMES[2]);
+  });
+
+  it('returns non-error outcomes', () => {
+    const outcomes = getOutcomes(
+      {
+        kind: 'MapDefinition',
+        name: 'd',
+        usecaseName: 'd',
+        statements: [
+          OUTCOMES[0],
+          OUTCOMES[1],
+          NESTED[0],
+          NESTED[1],
+          OTHER
+        ]
+      },
+      false
+    );
+    
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes).toContain(OUTCOMES[1]);
+    expect(outcomes).toContain(OUTCOMES[3]);
+  });
+});

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -67,10 +67,10 @@ export function formatIssueContext(issue: ValidationIssue): string {
       )}, but got ${issue.context.actual.join(', ')}`;
 
     case 'resultNotDefined':
-      return `Result not defined`;
+      return 'Result not defined';
 
     case 'errorNotDefined':
-      return `Error not defined`;
+      return 'Error not defined';
 
     case 'resultNotFound':
       if (isPrimitiveLiteralNode(issue.context.actualResult)) {
@@ -132,7 +132,7 @@ export function formatIssueContext(issue: ValidationIssue): string {
       return `Wrong Structure: expected ${expected}, but got "${actual.toString()}"`;
 
     case 'missingRequired':
-      return `Missing required field`;
+      return 'Missing required field';
 
     case 'wrongInput':
       if (!issue.context.expected.fields) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
Adds a test of `getOutcomes` and extracts `formatIssueContext` function from `formatIssues` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
