### PR TITLE
Provider id validation and unverified prefix

### DIFF
--- a/src/common/document/parser.test.ts
+++ b/src/common/document/parser.test.ts
@@ -94,25 +94,25 @@ describe('document name parsing', () => {
   });
 
   it('parses partial map name with unverified provider', () => {
-    const id = 'my-profile.unverified!x_provider';
+    const id = 'my-profile.unverified-x_provider';
 
     expect(parseDocumentId(id)).toEqual({
       kind: 'parsed',
       value: {
-        middle: ['my-profile', 'unverified!x_provider'],
+        middle: ['my-profile', 'unverified-x_provider'],
       },
     });
   });
 
   it('parses full map name with unverified provider', () => {
-    const id = 'our_scope/my-profile.unverified!x_provider.v4riant@1.2-rev567';
+    const id = 'our_scope/my-profile.unverified-x_provider.v4riant@1.2-rev567';
 
     expect(parseMapId(id)).toEqual({
       kind: 'parsed',
       value: {
         scope: 'our_scope',
         name: 'my-profile',
-        provider: 'unverified!x_provider',
+        provider: 'unverified-x_provider',
         variant: 'v4riant',
         version: {
           major: 1,

--- a/src/common/document/parser.test.ts
+++ b/src/common/document/parser.test.ts
@@ -93,6 +93,36 @@ describe('document name parsing', () => {
     });
   });
 
+  it('parses partial map name with unverified provider', () => {
+    const id = 'my-profile.unverified!x_provider';
+
+    expect(parseDocumentId(id)).toEqual({
+      kind: 'parsed',
+      value: {
+        middle: ['my-profile', 'unverified!x_provider'],
+      },
+    });
+  });
+
+  it('parses full map name with unverified provider', () => {
+    const id = 'our_scope/my-profile.unverified!x_provider.v4riant@1.2-rev567';
+
+    expect(parseMapId(id)).toEqual({
+      kind: 'parsed',
+      value: {
+        scope: 'our_scope',
+        name: 'my-profile',
+        provider: 'unverified!x_provider',
+        variant: 'v4riant',
+        version: {
+          major: 1,
+          minor: 2,
+          revision: 567,
+        },
+      },
+    });
+  });
+
   it('returns an error for uppercase', () => {
     const id = 'SCOPE/profile';
 

--- a/src/common/document/parser.test.ts
+++ b/src/common/document/parser.test.ts
@@ -75,14 +75,14 @@ describe('document name parsing', () => {
   });
 
   it('parses full map name', () => {
-    const id = 'our_scope/my-profile.x_prov1der.v4riant@1.2-rev567';
+    const id = 'our_scope/my-profile.x_provider.v4riant@1.2-rev567';
 
     expect(parseMapId(id)).toEqual({
       kind: 'parsed',
       value: {
         scope: 'our_scope',
         name: 'my-profile',
-        provider: 'x_prov1der',
+        provider: 'x_provider',
         variant: 'v4riant',
         version: {
           major: 1,
@@ -147,6 +147,24 @@ describe('document name parsing', () => {
     expect(parseProfileId(id)).toStrictEqual({
       kind: 'error',
       message: '"" is not a valid lowercase identifier',
+    });
+  });
+
+  it('returns an error for provider with number', () => {
+    const id = 'scope/profile.prov1der@1.0.0';
+
+    expect(parseMapId(id)).toStrictEqual({
+      kind: 'error',
+      message: '"prov1der" is not a valid lowercase identifier',
+    });
+  });
+
+  it('returns an error for unknow provider prefix is used', () => {
+    const id = 'scope/profile.myprefix!provider@1.0.0';
+
+    expect(parseMapId(id)).toStrictEqual({
+      kind: 'error',
+      message: '"myprefix!provider" is not a valid lowercase identifier',
     });
   });
 

--- a/src/common/document/parser.ts
+++ b/src/common/document/parser.ts
@@ -13,7 +13,6 @@ export type ParseResult<T> =
 const VERSION_DELIMITER = '@';
 const PART_DELIMITER = '.';
 const SCOPE_DELIMITER = '/';
-const PREFIX_DELIMITER = '!';
 const LABEL_DELIMITER = '-';
 
 const ID_NAME_RE = /^[a-z][a-z0-9_-]*$/;
@@ -24,7 +23,7 @@ export function isValidDocumentIdentifier(str: string): boolean {
   return ID_NAME_RE.test(str);
 }
 
-const PROVIDER_ID_RE = /^(unverified!)?[a-z][a-z_-]*$/;
+const PROVIDER_ID_RE = /^[a-z][a-z_-]*$/;
 /**
  * Checks wheter the identifier is valid with prefix
  */
@@ -129,28 +128,11 @@ export function parseDocumentId(id: string): ParseResult<DocumentId> {
   const version = parsedVersion?.value;
 
   const middle = id.split(PART_DELIMITER);
-  for (const part of middle) {
-    let prefix: string | null;
-    let id: string | null;
-
-    [prefix, id] = splitLimit(part, PREFIX_DELIMITER, 1);
-
-    if (!id) {
-      id = prefix;
-      prefix = null;
-    }
-
-    if (prefix && !isValidDocumentIdentifier(prefix)) {
+  for (const m of middle) {
+    if (!isValidDocumentIdentifier(m)) {
       return {
         kind: 'error',
-        message: `"${prefix}" is not valid `,
-      };
-    }
-
-    if (!isValidDocumentIdentifier(id)) {
-      return {
-        kind: 'error',
-        message: `"${id}" is not a valid lowercase identifier`,
+        message: `"${m}" is not a valid lowercase identifier`,
       };
     }
   }

--- a/src/common/document/parser.ts
+++ b/src/common/document/parser.ts
@@ -24,6 +24,14 @@ export function isValidDocumentIdentifier(str: string): boolean {
   return ID_NAME_RE.test(str);
 }
 
+const PROVIDER_ID_RE = /^(unverified!)?[a-z][a-z_-]*$/;
+/**
+ * Checks wheter the identifier is valid with prefix
+ */
+export function isValidProviderIdentifier(str: string): boolean {
+  return PROVIDER_ID_RE.test(str);
+}
+
 const VERSION_NUMBER_RE = /^[0-9]+$/;
 /**
  * Parses a singular version number or returns undefined.
@@ -233,10 +241,10 @@ export function parseMapId(id: string): ParseResult<MapDocumentId> {
 
   // parse name portion
   const [name, provider, variant] = base.middle;
-  if (provider === undefined) {
+  if (!isValidProviderIdentifier(provider)) {
     return {
       kind: 'error',
-      message: 'provider is not a valid lowercase identifier',
+      message: `"${provider}" is not a valid lowercase identifier`,
     };
   }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

This PR adds `!` delimiter for middle part prefixes and new regex for provider validation.

Changed validation for providers is backward incompatible change. so if someone is using provider with numeric character, it will be failing validation now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is needed to allow providers with `unverified!` prefix as well as own validation.

- https://www.notion.so/superface/Map-Id-and-unverified-prefix-for-providers-22903304a8824b908d0e7a4169a6a4a0
- https://github.com/superfaceai/spec/pull/29

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
