### PR TITLE
fix: Remove negative lookbehind from map-validator

### DIFF
--- a/src/interpreter/map-validator.ts
+++ b/src/interpreter/map-validator.ts
@@ -291,7 +291,7 @@ export class MapValidator implements MapAstVisitor {
 
   visitHttpCallStatementNode(node: HttpCallStatementNode): void {
     const variableExpressions = node.url
-      .match(/{([_A-Za-z][_0-9A-Za-z]*[.]?)*(?<![.])}/g)
+      .match(/{([_A-Za-z][_0-9A-Za-z]*[.]?)*[_0-9A-Za-z]}/g)
       ?.map(expression => expression.slice(1, -1));
 
     if (variableExpressions) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->
Removes negative lookbehind from regex that matches expressions in HTTP URL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Negative lookbehind is not supported in all browsers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
