### PR TITLE
Fix `parseDocumentId` error result for invalid document version

### DIFF
--- a/src/common/document/parser.test.ts
+++ b/src/common/document/parser.test.ts
@@ -138,4 +138,13 @@ describe('document name parsing', () => {
         'revision label must be in format `revN` where N is a non-negative integer',
     });
   });
+
+  it('returns an error for invalid version', () => {
+    const id = 'scope/profile.provider@.1';
+
+    expect(parseMapId(id)).toStrictEqual({
+      kind: 'error',
+      message: '.1 is not a valid version',
+    });
+  });
 });

--- a/src/common/document/parser.ts
+++ b/src/common/document/parser.ts
@@ -46,7 +46,14 @@ export function parseDocumentId(id: string): ParseResult<DocumentId> {
   let parsedVersion;
   const [versionRestId, splitVersion] = splitLimit(id, '@', 1);
   if (splitVersion !== undefined) {
-    parsedVersion = VersionRange.fromString(splitVersion);
+    try {
+      parsedVersion = VersionRange.fromString(splitVersion);
+    } catch (error) {
+      return {
+        kind: 'error',
+        message: `${splitVersion} is not a valid version`,
+      };
+    }
 
     // strip the version
     id = versionRestId;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->
`parseDocumentId` should be consistent and return `ParseResult` instead of throwing error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To have consistent parser API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
