### PR TITLE
fix(MapValidator): Validation of objects with dot notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handling variables that are written with dot notation, e.g. `output.is.nested = true`
 
 ## [1.0.0] - 2021-11-04
 ### Added

--- a/src/interpreter/__snapshots__/map-validator.test.ts.snap
+++ b/src/interpreter/__snapshots__/map-validator.test.ts.snap
@@ -893,16 +893,37 @@ Object {
 }
 `;
 
-exports[`MapValidator result & error result is an object that uses dot.notation for fields then validation will fail 1`] = `
+exports[`MapValidator result & error result is an object that uses dot.notation for fields with result then validation will fail 1`] = `
 Object {
   "profile-provider": Object {
     "errors": "ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
-ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"",
+ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
+15:34 PrimitiveLiteral - Wrong Structure: expected number, but got \\"false\\"
+16:25 PrimitiveLiteral - Wrong Structure: expected number, but got \\"true\\"
+18:24 JessieExpression - Wrong Variable Structure: variable output expected ObjectStructure, but got ObjectLiteral",
   },
 }
 `;
 
-exports[`MapValidator result & error result is an object that uses dot.notation for fields then validation will pass 1`] = `
+exports[`MapValidator result & error result is an object that uses dot.notation for fields with result then validation will pass 1`] = `
+Object {
+  "profile-provider": Object {},
+}
+`;
+
+exports[`MapValidator result & error result is an object that uses dot.notation for fields with strict result then validation will fail 1`] = `
+Object {
+  "profile-provider": Object {
+    "errors": "ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
+ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
+15:34 PrimitiveLiteral - Wrong Structure: expected number, but got \\"false\\"
+16:25 PrimitiveLiteral - Wrong Structure: expected number, but got \\"true\\"
+18:24 JessieExpression - Wrong Variable Structure: variable output expected ObjectStructure, but got ObjectLiteral",
+  },
+}
+`;
+
+exports[`MapValidator result & error result is an object that uses dot.notation for fields with strict result then validation will pass 1`] = `
 Object {
   "profile-provider": Object {},
 }
@@ -937,9 +958,7 @@ Object {
 
 exports[`MapValidator result & error result is variable reassigned (object) then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "ObjectLiteral - Wrong Object Structure: expected f1, f2, but got , ",
-  },
+  "profile-provider": Object {},
 }
 `;
 
@@ -961,7 +980,7 @@ Object {
 exports[`MapValidator result & error result is variable referenced in outcome then validation will fail 1`] = `
 Object {
   "profile-provider": Object {
-    "errors": "ObjectLiteral - Wrong Structure: expected string, but got \\"ObjectLiteral\\"
+    "errors": "5:13 ObjectLiteral - Wrong Structure: expected string, but got \\"ObjectLiteral\\"
 6:24 JessieExpression - Wrong Variable Structure: variable a expected string, but got ObjectLiteral",
   },
 }

--- a/src/interpreter/__snapshots__/map-validator.test.ts.snap
+++ b/src/interpreter/__snapshots__/map-validator.test.ts.snap
@@ -893,42 +893,6 @@ Object {
 }
 `;
 
-exports[`MapValidator result & error result is an object that uses dot.notation for fields with result then validation will fail 1`] = `
-Object {
-  "profile-provider": Object {
-    "errors": "ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
-ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
-15:34 PrimitiveLiteral - Wrong Structure: expected number, but got \\"false\\"
-16:25 PrimitiveLiteral - Wrong Structure: expected number, but got \\"true\\"
-18:24 JessieExpression - Wrong Variable Structure: variable output expected ObjectStructure, but got ObjectLiteral",
-  },
-}
-`;
-
-exports[`MapValidator result & error result is an object that uses dot.notation for fields with result then validation will pass 1`] = `
-Object {
-  "profile-provider": Object {},
-}
-`;
-
-exports[`MapValidator result & error result is an object that uses dot.notation for fields with strict result then validation will fail 1`] = `
-Object {
-  "profile-provider": Object {
-    "errors": "ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
-ObjectLiteral - Wrong Structure: expected number, but got \\"ObjectLiteral\\"
-15:34 PrimitiveLiteral - Wrong Structure: expected number, but got \\"false\\"
-16:25 PrimitiveLiteral - Wrong Structure: expected number, but got \\"true\\"
-18:24 JessieExpression - Wrong Variable Structure: variable output expected ObjectStructure, but got ObjectLiteral",
-  },
-}
-`;
-
-exports[`MapValidator result & error result is an object that uses dot.notation for fields with strict result then validation will pass 1`] = `
-Object {
-  "profile-provider": Object {},
-}
-`;
-
 exports[`MapValidator result & error result is conditioned then validation will pass 1`] = `
 Object {
   "profile-provider": Object {

--- a/src/interpreter/map-validator.test.ts
+++ b/src/interpreter/map-validator.test.ts
@@ -5,7 +5,112 @@ import {
 } from '@superfaceai/ast';
 
 import { parseMap, parseProfile, Source } from '..';
+import { ProfileOutput, ValidationIssue } from '.';
 import { formatIssues, getProfileOutput, validateMap } from './utils';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBeValidMap(
+        profileOutput: ProfileOutput,
+        warning: string,
+        error?: string
+      ): R;
+    }
+  }
+}
+
+expect.extend({
+  toBeValidMap(
+    map: MapASTNode,
+    profileOutput: ProfileOutput,
+    warning: string,
+    error?: string
+  ) {
+    const result = validateMap(profileOutput, map);
+
+    let message = '';
+    let pass = true;
+    let errors: ValidationIssue[] = [];
+    let warnings: ValidationIssue[] = [];
+
+    if (!result.pass) {
+      errors = result.errors;
+    }
+    if (result.warnings && result.warnings.length > 0) {
+      warnings = result.warnings;
+    }
+
+    if (this.isNot) {
+      pass = false;
+
+      if (!error) {
+        pass = !pass;
+        message = 'expected to fail';
+      } else {
+        const err = formatIssues(errors);
+        const warn = formatIssues(warnings);
+
+        if (!err.includes(error)) {
+          pass = !pass;
+          message = `expected to find error "${error}" in "${err}"`;
+          if (warning !== '' && !warn.includes(warning)) {
+            message += `, expected to find warning "${warning}" in "${warn}"`;
+          }
+        } else if (warning !== '' && !warn.includes(warning)) {
+          pass = !pass;
+          message = `expected to find warning "${warning}" in "${warn}"`;
+        }
+      }
+    } else {
+      const warn = formatIssues(warnings);
+      const err = formatIssues(errors);
+      if (errors.length > 0) {
+        pass = !pass;
+        message = `expected to pass, errors: ${err}, warnings: ${warn}`;
+      } else if (warning && warning !== '' && !warn.includes(warning)) {
+        pass = !pass;
+        message = `expected to find warning "${warning}" in "${warn}"`;
+      }
+    }
+
+    return {
+      pass,
+      message: (): string => message,
+    };
+  },
+});
+
+function validWithWarnings(
+  profile: ProfileDocumentNode,
+  maps: MapASTNode[],
+  ...warnings: string[]
+): void {
+  const profileOutput = getProfileOutput(profile);
+
+  it('then validation will pass with warnings', () => {
+    maps.forEach((map, index) => {
+      expect(map).toBeValidMap(profileOutput, warnings[index]);
+    });
+  });
+}
+
+function invalidWithErrors(
+  profile: ProfileDocumentNode,
+  maps: MapASTNode[],
+  ...results: string[]
+): void {
+  const profileOutput = getProfileOutput(profile);
+
+  it('then validation will fail with errors', () => {
+    let i = 0;
+    maps.forEach(map => {
+      expect(map).not.toBeValidMap(profileOutput, results[i + 1], results[i]);
+      i += 2;
+    });
+  });
+}
 
 function getIssues(profile: ProfileDocumentNode, maps: MapASTNode[]) {
   const profileOutput = getProfileOutput(profile);
@@ -594,8 +699,17 @@ describe('MapValidator', () => {
             }`
           );
 
-          valid(profileAst, [mapAst1]);
-          invalid(profileAst, [mapAst2]);
+          validWithWarnings(profileAst, [mapAst1]);
+          invalidWithErrors(
+            profileAst,
+            [mapAst2],
+            `ObjectLiteral - Wrong Structure: expected number, but got "ObjectLiteral"
+ObjectLiteral - Wrong Structure: expected number, but got "ObjectLiteral"
+15:34 PrimitiveLiteral - Wrong Structure: expected number, but got "false"
+16:25 PrimitiveLiteral - Wrong Structure: expected number, but got "true"
+18:24 JessieExpression - Wrong Variable Structure: variable output expected ObjectStructure, but got ObjectLiteral`,
+            ''
+          );
         });
 
         describe('with strict result', () => {
@@ -612,8 +726,17 @@ describe('MapValidator', () => {
             }`
           );
 
-          valid(profileAst, [mapAst1]);
-          invalid(profileAst, [mapAst2]);
+          validWithWarnings(profileAst, [mapAst1]);
+          invalidWithErrors(
+            profileAst,
+            [mapAst2],
+            `ObjectLiteral - Wrong Structure: expected number, but got "ObjectLiteral"
+ObjectLiteral - Wrong Structure: expected number, but got "ObjectLiteral"
+15:34 PrimitiveLiteral - Wrong Structure: expected number, but got "false"
+16:25 PrimitiveLiteral - Wrong Structure: expected number, but got "true"
+18:24 JessieExpression - Wrong Variable Structure: variable output expected ObjectStructure, but got ObjectLiteral`,
+            ''
+          );
         });
       });
     });

--- a/src/interpreter/map-validator.test.ts
+++ b/src/interpreter/map-validator.test.ts
@@ -547,24 +547,18 @@ describe('MapValidator', () => {
       });
 
       describe('that uses dot.notation for fields', () => {
-        const profileAst = parseProfileFromSource(
-          `usecase Test {
-            result {
-              f1 {
-                f2 {
-                  inner number
-                }
-              }
-              f2 number
-            }    
-          }`
-        );
         const mapAst1 = parseMapFromSource(
           `map Test {
             map result {
               f1.f2.inner = 1
               f2 = 2
             }
+
+            output = {}
+            output.f1.f2.inner = 1
+            output.f2 = 2
+
+            map result output
           }`
         );
         const mapAst2 = parseMapFromSource(
@@ -577,11 +571,50 @@ describe('MapValidator', () => {
               f1.f2.inner = 1
               f2.f1 = 2
             }
+
+            output = {}
+            output.f1.f2.inner = false
+            output.f2 = true
+
+            map result output
           }`
         );
 
-        valid(profileAst, [mapAst1]);
-        invalid(profileAst, [mapAst2]);
+        describe('with result', () => {
+          const profileAst = parseProfileFromSource(
+            `usecase Test {
+              result {
+                f1 {
+                  f2 {
+                    inner number
+                  }
+                }
+                f2 number
+              }    
+            }`
+          );
+
+          valid(profileAst, [mapAst1]);
+          invalid(profileAst, [mapAst2]);
+        });
+
+        describe('with strict result', () => {
+          const profileAst = parseProfileFromSource(
+            `usecase Test {
+              result {
+                f1! {
+                  f2! {
+                    inner! number!
+                  }!
+                }!
+                f2! number!
+              }!  
+            }`
+          );
+
+          valid(profileAst, [mapAst1]);
+          invalid(profileAst, [mapAst2]);
+        });
       });
     });
 

--- a/src/interpreter/map-validator.ts
+++ b/src/interpreter/map-validator.ts
@@ -26,6 +26,7 @@ import {
 import createDebug from 'debug';
 import * as ts from 'typescript';
 
+import { buildAssignment } from '.';
 import { RETURN_CONSTRUCTS } from './constructs';
 import { ValidationIssue } from './issue';
 import {
@@ -447,8 +448,27 @@ export class MapValidator implements MapAstVisitor {
 
   visitSetStatementNode(node: SetStatementNode): void {
     node.assignments.forEach(assignment => {
+      // Init new variables if object used in dot notation wasn't defined before
+      if (assignment.key.length > 1) {
+        const keys = [];
+        for (const key of assignment.key) {
+          keys.push(key);
+
+          if (this.variables[keys.join('.')] === undefined) {
+            this.addVariableToStack(
+              buildAssignment(keys, {
+                kind: 'ObjectLiteral',
+                fields: [],
+                location: assignment.location,
+              }),
+              true
+            );
+          }
+        }
+      }
+
       this.visit(assignment.value);
-      this.addVariableToStack(assignment);
+      this.addVariableToStack(assignment, false);
     });
   }
 
@@ -561,7 +581,7 @@ export class MapValidator implements MapAstVisitor {
           context: {
             path: this.getPath(node),
             name: variableName,
-            expected: this.currentStructure,
+            expected: type,
             actual: variable,
           },
         });
@@ -638,22 +658,13 @@ export class MapValidator implements MapAstVisitor {
 
       // it should not validate against final value when dot.notation is used
       if (field.key.length > 1) {
-        const [head, ...tail] = field.key;
-        const assignment: AssignmentNode = {
-          kind: 'Assignment',
-          key: [head],
-          value: {
-            kind: 'ObjectLiteral',
-            fields: [
-              {
-                kind: 'Assignment',
-                key: tail,
-                value: field.value,
-              },
-            ],
-          },
+        const [, ...tail] = field.key;
+
+        const objectLiteral: ObjectLiteralNode = {
+          kind: 'ObjectLiteral',
+          fields: [buildAssignment(tail, field.value)],
         };
-        visitResult = this.visit(assignment);
+        visitResult = this.visit(objectLiteral);
       } else {
         visitResult = this.visit(field);
       }
@@ -721,49 +732,41 @@ export class MapValidator implements MapAstVisitor {
       : [node.kind];
   }
 
-  private cleanUpVariables(key: string): void {
-    for (const variableKey of Object.keys(this.variables)) {
-      if (
-        variableKey.length > key.length &&
-        variableKey[key.length] === '.' &&
-        variableKey.startsWith(key)
-      ) {
-        delete this.variables[variableKey];
-      }
-    }
-  }
-
+  /**
+   * Handles storing variables with dot notation. If there is assignment with
+   * multiple keys, there should be an object containing referenced or other field.
+   * This function handles adding fields to object variable stored in validator for
+   * later validation of this object.
+   */
   private handleVariable(assignment: AssignmentNode): void {
     if (assignment.key.length > 1) {
       const keys: string[] = [];
-      const tmpField: AssignmentNode = {
-        kind: 'Assignment',
-        key: Array.from(assignment.key),
-        value: assignment.value,
-      };
+      const tmpKeys = Array.from(assignment.key);
 
       for (const assignmentKey of assignment.key) {
         keys.push(assignmentKey);
-        tmpField.key.shift();
 
-        if (tmpField.key.length === 0) {
+        if (tmpKeys.length === 1) {
           return;
         }
+
+        tmpKeys.shift();
 
         let isReassigned = false;
         const variable = this.variables[keys.join('.')];
         const value: ObjectLiteralNode = {
           kind: 'ObjectLiteral',
           fields: [],
+          location: variable.location,
         };
 
         if (variable && isObjectLiteralNode(variable)) {
-          const fieldKey = tmpField.key.join('.');
+          const fieldKey = tmpKeys.join('.');
 
           for (const variableField of variable.fields) {
             if (variableField.key.join('.') === fieldKey) {
+              variableField.value = assignment.value;
               isReassigned = true;
-              variableField.value = tmpField.value;
             }
           }
 
@@ -771,28 +774,37 @@ export class MapValidator implements MapAstVisitor {
         }
 
         if (!isReassigned) {
-          value.fields.push(tmpField);
+          value.fields.push(
+            buildAssignment(
+              Array.from(tmpKeys),
+              assignment.value,
+              assignment.location
+            )
+          );
         }
 
-        this.addVariableToStack({
-          kind: 'Assignment',
-          key: keys,
-          value,
-        });
+        this.addVariableToStack(buildAssignment(keys, value), true);
       }
     }
   }
 
-  private addVariableToStack(assignment: AssignmentNode): void {
+  private addVariableToStack(
+    assignment: AssignmentNode,
+    handled: boolean
+  ): void {
     const key = assignment.key.join('.');
 
-    const variable: Record<string, LiteralNode> = {};
-    variable[key] = assignment.value;
+    const variables: Record<string, LiteralNode> = {};
+    variables[key] = assignment.value;
 
-    this.stackTop.variables = mergeVariables(this.stackTop.variables, variable);
+    this.stackTop.variables = mergeVariables(
+      this.stackTop.variables,
+      variables
+    );
 
-    this.handleVariable(assignment);
-    this.cleanUpVariables(key);
+    if (!handled) {
+      this.handleVariable(assignment);
+    }
   }
 
   private newStack(type: Stack['type'], name?: string): void {

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -1,4 +1,5 @@
 import {
+  AssignmentNode,
   isCallStatementNode,
   isHttpCallStatementNode,
   isObjectLiteralNode,
@@ -6,6 +7,7 @@ import {
   isPrimitiveLiteralNode,
   isUseCaseDefinitionNode,
   LiteralNode,
+  LocationSpan,
   MapASTNode,
   MapDefinitionNode,
   OperationDefinitionNode,
@@ -471,3 +473,9 @@ export function getVariableName(
 
   return 'undefined';
 }
+
+export const buildAssignment = (
+  key: string[],
+  value: LiteralNode,
+  location?: LocationSpan
+): AssignmentNode => ({ kind: 'Assignment', key, value, location });


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->
Refactors handling variables that are written with dot notation, e.g. `output.is.nested = true`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Wrong linter errors.

```
Map for profile: "address/geocoding" and provider: "nominatim" found on local filesystem

🆗 Parsing map file: /station/capabilities/address/geocoding/maps/nominatim.suma

⚠️ Validating profile: /station/capabilities/address/geocoding/profile.supr to map: /station/capabilities/address/geocoding/maps/nominatim.suma
ObjectLiteral - Wrong Object Structure: expected addressCountry, addressRegion, addressLocality, streetAddress, postalCode, formattedAddress, but got , , , , , , , , , , , 

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
