### PR TITLE
fix: SyntaxRuleNever causing wrong error messages and spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate arguments in inline call only against input
 - Unwrap non null structure in validation of nested properties
 - Remove limited validation of binary expressions and let other constructs handle them
+- `SyntaxRuleNever` causing a wrong error message
 
 ## [1.0.0] - 2021-11-04
 ### Added

--- a/src/language/error.ts
+++ b/src/language/error.ts
@@ -139,19 +139,37 @@ function generateErrorVisualization(
   const maxLineNumberLog =
     Math.log10(sourceLocation.start.line + sourceTextLines.length) + 1;
 
-  const visualization = renderErrorVisualization(
-    sourceTextLines,
-    location,
-    maxLineNumberLog,
-    sourceLocation.start.line + visBlock.lineOffset,
-    visBlock.start
-  );
+  // Generate visualization only if the error span is not empty
+  let visualization = '';
+  if (location.start.charIndex < location.end.charIndex) {
+    visualization = renderErrorVisualization(
+      sourceTextLines,
+      location,
+      maxLineNumberLog,
+      sourceLocation.start.line + visBlock.lineOffset,
+      visBlock.start
+    );
+  }
 
   return {
     visualization,
     maxLineNumberLog,
     sourceLocation,
   };
+}
+
+function isString(i: string | undefined): i is string {
+  return i !== undefined;
+}
+
+function formatHints(...hints: (string | undefined)[]): string {
+  const filtered: string[] = hints.filter(isString);
+
+  if (filtered.length === 0) {
+    return '';
+  }
+
+  return filtered.map(h => `Hint: ${h}`).join('\n');
 }
 
 export const enum SyntaxErrorCategory {
@@ -164,18 +182,42 @@ export const enum SyntaxErrorCategory {
   /** Jessie forbidden construct error */
   JESSIE_VALIDATION = 'Jessie validation',
 }
+function errorCategoryStrings(category: SyntaxErrorCategory): {
+  categoryDetail?: string;
+  categoryHint?: string;
+} {
+  const result: {
+    categoryDetail?: string;
+    categoryHint?: string;
+  } = {
+    categoryDetail: undefined,
+    categoryHint: undefined,
+  };
+
+  switch (category) {
+    case SyntaxErrorCategory.JESSIE_SYNTAX:
+    case SyntaxErrorCategory.JESSIE_VALIDATION:
+      result.categoryDetail = 'Error in script syntax';
+      result.categoryHint =
+        'This was parsed in script context, it might be an error in comlink syntax instead';
+      break;
+  }
+
+  return result;
+}
 
 export type ProtoError = {
   /** Relative span of this error with respect to the token it is attached to. */
   readonly relativeSpan: CharIndexSpan;
   readonly detail?: string;
   readonly category: SyntaxErrorCategory;
-  readonly hint?: string;
+  readonly hints: string[];
 };
 
 export class SyntaxError {
   /** Additional message attached to the error. */
   readonly detail: string;
+  readonly hints: string[];
 
   constructor(
     /** Input source that is being parsed. */
@@ -185,10 +227,11 @@ export class SyntaxError {
     /** Category of this error. */
     readonly category: SyntaxErrorCategory,
     detail?: string,
-    /** Optional hint that is emitted to help with the resolution. */
-    readonly hint?: string
+    /** Optional hints that are emitted to help with the resolution. */
+    hints?: string[]
   ) {
     this.detail = detail ?? 'Invalid or unexpected token';
+    this.hints = hints ?? [];
   }
 
   static fromSyntaxRuleNoMatch(
@@ -219,6 +262,7 @@ export class SyntaxError {
       }
     }
 
+    // The default location is invalid on purpose
     const location = result.attempts.token?.location ?? {
       start: { line: 0, column: 0, charIndex: 0 },
       end: { line: 0, column: 0, charIndex: 0 },
@@ -251,21 +295,22 @@ export class SyntaxError {
     const { visualization, maxLineNumberLog, sourceLocation } =
       generateErrorVisualization(this.source, this.location);
 
-    let categoryInfo = '';
-    switch (this.category) {
-      case SyntaxErrorCategory.JESSIE_SYNTAX:
-      case SyntaxErrorCategory.JESSIE_VALIDATION:
-        categoryInfo = 'Error in script syntax: ';
-        break;
+    const { categoryDetail, categoryHint } = errorCategoryStrings(
+      this.category
+    );
+
+    let detail = this.detail;
+    if (categoryDetail !== undefined) {
+      detail = `${categoryDetail}: ${detail}`;
     }
 
-    const errorLine = `SyntaxError: ${categoryInfo}${this.detail}`;
+    const errorLine = `SyntaxError: ${detail}`;
     const locationLinePrefix = ' '.repeat(maxLineNumberLog) + '--> ';
     const locationLine = `${locationLinePrefix}${this.source.fileName}:${sourceLocation.start.line}:${sourceLocation.start.column}`;
 
-    const maybeHint = this.hint ? `Hint: ${this.hint}\n` : '';
+    const maybeHints = formatHints(...this.hints, categoryHint);
 
-    return `${errorLine}\n${locationLine}\n${visualization}\n${maybeHint}`;
+    return `${errorLine}\n${locationLine}\n${visualization}\n${maybeHints}`;
   }
 
   get message(): string {

--- a/src/language/jessie/transpiler/transpiler.ts
+++ b/src/language/jessie/transpiler/transpiler.ts
@@ -83,6 +83,7 @@ export function transpileScript(
         end: (diag.start ?? 0) + Math.max(1, diag.length ?? 0),
       },
       detail,
+      hints: [],
     };
   }
 

--- a/src/language/jessie/validator/validator.test.ts
+++ b/src/language/jessie/validator/validator.test.ts
@@ -13,7 +13,7 @@ declare global {
 expect.extend({
   toBeValidScript(script: string, ...errors: string[]) {
     function formatError(err: ForbiddenConstructProtoError): string {
-      const hint = err.hint ?? 'not provided';
+      const hint = err.hints.join('; ') ?? 'not provided';
 
       return `${err.detail} (hint: ${hint})`;
     }
@@ -35,7 +35,7 @@ expect.extend({
           const err = protoErrors[i];
           if (
             !err.detail.includes(errors[i]) &&
-            !err.hint?.includes(errors[i])
+            !err.hints?.includes(errors[i])
           ) {
             pass = !pass;
             message = `expected to find hint "${errors[i]}" in "${formatError(
@@ -255,7 +255,7 @@ describe('validator', () => {
       expect(errors[0]).toStrictEqual({
         category: 'Jessie validation',
         detail: 'ShorthandPropertyAssignment construct is not supported',
-        hint: 'Use `{ name: name, foo: foo }` instead',
+        hints: ['Use `{ name: name, foo: foo }` instead'],
         relativeSpan: {
           start: 38,
           end: 42,

--- a/src/language/jessie/validator/validator.ts
+++ b/src/language/jessie/validator/validator.ts
@@ -68,7 +68,7 @@ export function validateScript(input: string): ForbiddenConstructProtoError[] {
 
         errors.push({
           detail: `${ts.SyntaxKind[node.kind]} construct is not supported`,
-          hint: rule.hint(input, node),
+          hints: [rule.hint(input, node)],
           relativeSpan: { start: node.getStart(), end: node.getEnd() },
           category: SyntaxErrorCategory.JESSIE_VALIDATION,
         });
@@ -81,6 +81,7 @@ export function validateScript(input: string): ForbiddenConstructProtoError[] {
         detail: `${ts.SyntaxKind[node.kind]} construct is not supported`,
         relativeSpan: { start: node.getStart(), end: node.getEnd() },
         category: SyntaxErrorCategory.JESSIE_VALIDATION,
+        hints: [],
       });
     }
 

--- a/src/language/lexer/lexer.ts
+++ b/src/language/lexer/lexer.ts
@@ -289,7 +289,7 @@ export class Lexer implements LexerTokenStream<[LexerToken, boolean]> {
     if (tokenParseResult.kind === 'error') {
       let category: SyntaxErrorCategory;
       let detail: string | undefined;
-      let hint: string | undefined;
+      let hints: string[];
       let relativeSpan: CharIndexSpan;
 
       // Single-error results are easy
@@ -298,15 +298,16 @@ export class Lexer implements LexerTokenStream<[LexerToken, boolean]> {
 
         category = error.category;
         detail = error.detail;
-        hint = error.hint;
+        hints = error.hints;
         relativeSpan = error.relativeSpan;
       } else {
         // multi-error results combine all errors and hints into one, the span is the one that covers all the errors
         category = SyntaxErrorCategory.LEXER;
+
         detail = tokenParseResult.errors
           .map(err => err.detail ?? '')
           .join('; ');
-        hint = tokenParseResult.errors.map(err => err.hint ?? '').join('; ');
+        hints = tokenParseResult.errors.flatMap(err => err.hints);
         relativeSpan = tokenParseResult.errors
           .map(err => err.relativeSpan)
           .reduce((acc, curr) => {
@@ -351,7 +352,7 @@ export class Lexer implements LexerTokenStream<[LexerToken, boolean]> {
         errorLocation,
         category,
         detail,
-        hint
+        hints
       );
 
       return new LexerToken(

--- a/src/language/lexer/sublexer/default/number.ts
+++ b/src/language/lexer/sublexer/default/number.ts
@@ -54,6 +54,7 @@ export function tryParseNumberLiteral(
               'Expected a number following a sign or an integer base prefix',
             category: SyntaxErrorCategory.LEXER,
             relativeSpan: { start: 0, end: prefixLength + 1 },
+            hints: [],
           },
         ],
       };

--- a/src/language/lexer/sublexer/default/string.ts
+++ b/src/language/lexer/sublexer/default/string.ts
@@ -204,6 +204,7 @@ export function tryParseStringLiteral(
             relativeSpan: { start: 0, end: eatenChars },
             detail: 'Unexpected EOF',
             category: SyntaxErrorCategory.LEXER,
+            hints: [],
           },
         ],
       };
@@ -221,6 +222,7 @@ export function tryParseStringLiteral(
               relativeSpan: { start: 0, end: eatenChars + 1 },
               detail: 'Invalid escape sequence',
               category: SyntaxErrorCategory.LEXER,
+              hints: [],
             },
           ],
         };

--- a/src/language/lexer/sublexer/jessie/expression.ts
+++ b/src/language/lexer/sublexer/jessie/expression.ts
@@ -33,7 +33,7 @@ function processScriptText(
       errors: transRes.errors.map(err => {
         return {
           detail: err.detail,
-          hint: err.hint,
+          hints: err.hints,
           category: err.category,
           relativeSpan: {
             start: err.relativeSpan.start - SCRIPT_WRAP.start.length,

--- a/src/language/source.ts
+++ b/src/language/source.ts
@@ -10,9 +10,9 @@ export type Location = AstLocation;
 export type LocationSpan = AstLocationSpan;
 export type LocationOffset = {
   /** Line offset - this is basically how many lines there are preceding the one in question */
-  line: 0;
+  line: number;
   /** Column offset - this only applies to the first line */
-  column: 0;
+  column: number;
 };
 
 export type CharIndexSpan = {

--- a/src/language/syntax/rule.ts
+++ b/src/language/syntax/rule.ts
@@ -786,10 +786,10 @@ export class SyntaxRuleNever<R> extends SyntaxRule<R> {
     super();
   }
 
-  tryMatch(_tokens: LexerTokenStream): RuleResult<R> {
+  tryMatch(tokens: LexerTokenStream): RuleResult<R> {
     return {
       kind: 'nomatch',
-      attempts: new MatchAttempts(undefined, [this]),
+      attempts: new MatchAttempts(tokens.peek().value, [this]),
     };
   }
 
@@ -804,7 +804,7 @@ export class SyntaxRuleDebugLog<R> extends SyntaxRule<R> {
   }
 
   tryMatch(tokens: LexerTokenStream): RuleResult<R> {
-    const nextToken = tokens.peek();
+    const nextToken = tokens.peek().value;
 
     let result;
     try {


### PR DESCRIPTION
## Description
Fixes SyntaxRuleNever hijacking error spans into the beginning of the file

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
