### PR TITLE
chore: refactor syntax error formatting

### DIFF
--- a/src/language/jessie/transpiler/transpiler.ts
+++ b/src/language/jessie/transpiler/transpiler.ts
@@ -7,7 +7,7 @@ const SCRIPT_OUTPUT_TARGET = ts.ScriptTarget.ES3;
 const AFTER_TRANSFORMERS: ts.TransformerFactory<ts.SourceFile>[] = [];
 
 export type JessieSyntaxProtoError = ProtoError & {
-  category: SyntaxErrorCategory.JESSIE_SYNTAX;
+  category: SyntaxErrorCategory.SCRIPT_SYNTAX;
 };
 
 export function transpileScript(
@@ -77,7 +77,7 @@ export function transpileScript(
     }
 
     syntaxProtoError = {
-      category: SyntaxErrorCategory.JESSIE_SYNTAX,
+      category: SyntaxErrorCategory.SCRIPT_SYNTAX,
       relativeSpan: {
         start: diag.start ?? 0,
         end: (diag.start ?? 0) + Math.max(1, diag.length ?? 0),

--- a/src/language/jessie/validator/validator.test.ts
+++ b/src/language/jessie/validator/validator.test.ts
@@ -253,7 +253,7 @@ describe('validator', () => {
 
       expect(errors.length).toBe(1);
       expect(errors[0]).toStrictEqual({
-        category: 'Jessie validation',
+        category: 'Script validation',
         detail: 'ShorthandPropertyAssignment construct is not supported',
         hints: ['Use `{ name: name, foo: foo }` instead'],
         relativeSpan: {

--- a/src/language/jessie/validator/validator.ts
+++ b/src/language/jessie/validator/validator.ts
@@ -45,7 +45,7 @@ function constructDebugVisualTree(root: ts.Node): string {
 
 export type ForbiddenConstructProtoError = ProtoError & {
   detail: string;
-  category: SyntaxErrorCategory.JESSIE_VALIDATION;
+  category: SyntaxErrorCategory.SCRIPT_VALIDATION;
 };
 export function validateScript(input: string): ForbiddenConstructProtoError[] {
   const errors: ForbiddenConstructProtoError[] = [];
@@ -70,7 +70,7 @@ export function validateScript(input: string): ForbiddenConstructProtoError[] {
           detail: `${ts.SyntaxKind[node.kind]} construct is not supported`,
           hints: [rule.hint(input, node)],
           relativeSpan: { start: node.getStart(), end: node.getEnd() },
-          category: SyntaxErrorCategory.JESSIE_VALIDATION,
+          category: SyntaxErrorCategory.SCRIPT_VALIDATION,
         });
       }
     }
@@ -80,7 +80,7 @@ export function validateScript(input: string): ForbiddenConstructProtoError[] {
       errors.push({
         detail: `${ts.SyntaxKind[node.kind]} construct is not supported`,
         relativeSpan: { start: node.getStart(), end: node.getEnd() },
-        category: SyntaxErrorCategory.JESSIE_VALIDATION,
+        category: SyntaxErrorCategory.SCRIPT_VALIDATION,
         hints: [],
       });
     }


### PR DESCRIPTION
## Description
Refactors SyntaxError formatting. Exposes separate formatting methods for parts of the formatted error. Updates "Jessie" to "Script". Adds category hints to the error hints in the constructor, so that they are visible for other uses.

## Motivation and Context
Language server diagnostics benefit from this.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I haven't repeated the code. (DRY)
- [x] All new and existing tests passed.
