### PR TITLE
Expose enum variant name in structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `EnumStructure` added name field
+
 ## [1.1.0] - 2022-01-19
 ### Added
 - Http call can now select service id, e.g. `http VERB "id" "url" {`

--- a/src/interpreter/profile-io-analyzer.test.ts
+++ b/src/interpreter/profile-io-analyzer.test.ts
@@ -115,6 +115,35 @@ describe('ProfileIOAnalyzer', () => {
       });
     });
 
+    describe('and Result is Enum Type with named variant', () => {
+      const ast = parseProfileFromSource(
+        `usecase Test {
+          input {}
+          result enum { a, b = 'c' }
+        }`
+      );
+
+      const analyzer = new ProfileIOAnalyzer();
+      const expected: ProfileOutput = {
+        header,
+        usecases: [
+          {
+            useCaseName: 'Test',
+
+            result: {
+              kind: 'EnumStructure',
+              enums: [{ value: 'a' }, { name: 'b', value: 'c' }],
+            },
+          },
+        ],
+      };
+
+      test('then result contain EnumStructure', () => {
+        const output = analyzer.visit(ast);
+        expect(output).toMatchObject(expected);
+      });
+    });
+
     describe('and Result is Model Type which is defined in definition aswell as useCaseDefinition', () => {
       const ast = parseProfileFromSource(
         `model myModel boolean

--- a/src/interpreter/profile-io-analyzer.test.ts
+++ b/src/interpreter/profile-io-analyzer.test.ts
@@ -703,10 +703,12 @@ describe('ProfileIOAnalyzer', () => {
                 description: 'It is either bad or badder',
                 enums: [
                   {
+                    name: 'bad',
                     value: 'bad',
                     title: 'This means bad',
                   },
                   {
+                    name: 'badder',
                     value: 'badder',
                     title: 'This means badder',
                   },

--- a/src/interpreter/profile-io-analyzer.ts
+++ b/src/interpreter/profile-io-analyzer.ts
@@ -155,7 +155,7 @@ export class ProfileIOAnalyzer implements ProfileAstVisitor {
     return {
       kind: 'EnumStructure',
       enums: node.values.map(value =>
-        addDoc(value, { value: this.visit(value) })
+        addDoc(value, { name: value.name, value: this.visit(value) })
       ),
     };
   }

--- a/src/interpreter/profile-output.ts
+++ b/src/interpreter/profile-output.ts
@@ -36,7 +36,10 @@ export interface PrimitiveStructure extends Structure, DocumentedStructure {
  */
 export interface EnumStructure extends Structure, DocumentedStructure {
   kind: 'EnumStructure';
-  enums: ({ value: string | number | boolean } & DocumentedStructure)[];
+  enums: ({
+    name?: string | undefined;
+    value: string | number | boolean;
+  } & DocumentedStructure)[];
 }
 
 /**


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

Follow up for #90

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I need to be able to access enum variant name while working with `ProfileOutput`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
