### PR TITLE
Fix/validator property access understand list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Script sublexer infinite loop on some invalid scripts (nesting ignoring EOF token)
+- Validator now properly handles list property access
 
 ## [1.2.0] - 2022-04-13
 ### Added

--- a/src/interpreter/__snapshots__/map-validator.test.ts.snap
+++ b/src/interpreter/__snapshots__/map-validator.test.ts.snap
@@ -1,8 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MapValidator input input has an array with element access then validation will pass 1`] = `
+Object {
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
+}
+`;
+
 exports[`MapValidator result & error error is PrimitiveTypeName then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:21 PrimitiveLiteral - Wrong Structure: expected NOTFOUND or BADREQUEST, but got \\"wrong\\"",
   },
 }
@@ -10,13 +17,16 @@ Object {
 
 exports[`MapValidator result & error error is PrimitiveTypeName then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is a list non null list with primitive or object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
+    "errors": "4:7 MapDefinition - No Error outcome defined",
+  },
+  "profile-provider#1": Object {
     "errors": "5:23 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [true, 2]
 6:23 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [true, 2, {}]
 7:23 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [[true]]",
@@ -26,13 +36,14 @@ Object {
 
 exports[`MapValidator result & error error is a list non null list with primitive or object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is a list non null primitive or object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:23 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}!], but got [null]
 6:23 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}!], but got [undefined]
 7:23 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}!], but got [true, 2]
@@ -44,13 +55,14 @@ Object {
 
 exports[`MapValidator result & error error is a list non null primitive or object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is a list non null primitive type or possibly null object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:23 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}], but got [true, 2]
 6:23 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}], but got [true, 2, {}]
 7:23 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}], but got [[true]]",
@@ -60,13 +72,14 @@ Object {
 
 exports[`MapValidator result & error error is a list non null primitive type or possibly null object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is a list non null primitive type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 NullKeyword - Wrong Structure: expected boolean!, but got null
 6:24 ObjectLiteralExpression - Wrong Structure: expected boolean, but got {}
 7:30 ObjectLiteralExpression - Wrong Structure: expected boolean, but got {}
@@ -78,13 +91,14 @@ Object {
 
 exports[`MapValidator result & error error is a list non null primitive type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is a list primitive or object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:23 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [2]
 6:23 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [[true]]
 7:23 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [true, 2, {}]",
@@ -94,13 +108,14 @@ Object {
 
 exports[`MapValidator result & error error is a list primitive or object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is a list primitive type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 FirstLiteralToken - Wrong Structure: expected boolean, but got 2
 6:24 ObjectLiteralExpression - Wrong Structure: expected boolean, but got {}",
   },
@@ -109,13 +124,22 @@ Object {
 
 exports[`MapValidator result & error error is a list primitive type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
+}
+`;
+
+exports[`MapValidator result & error error is an object extra field then validation will pass with warnings 1`] = `
+Object {
+  "profile-provider#0": Object {
+    "warnings": "5:23 ObjectLiteral - Wrong Object Structure: expected {f1: string}, but got {f2: \\"what\\"}",
+  },
 }
 `;
 
 exports[`MapValidator result & error error is an object fields: f1, f2, where f2 is non null then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "7:20 NullKeyword - Wrong Structure: expected number!, but got null
 10:20 NullKeyword - Wrong Structure: expected number!, but got null",
     "warnings": "9:23 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number!}, but got {f2: null, f3: 3}",
@@ -125,16 +149,14 @@ Object {
 
 exports[`MapValidator result & error error is an object fields: f1, f2, where f2 is non null then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "24:23 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number!}, but got {f1: \\"some string\\", f2: 2, f3: 3}
-29:23 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number!}, but got {f2: 2, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object non null field f1 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "6:20 NullKeyword - Wrong Structure: expected string!, but got null
 9:20 ArrayLiteralExpression - Wrong Structure: expected string, but got [\\"some\\", \\"key\\"]",
   },
@@ -143,16 +165,14 @@ Object {
 
 exports[`MapValidator result & error error is an object non null field f1 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "10:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!}, but got {f1: \\"some string\\", f3: 3}
-14:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!}, but got {f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object non null fields: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "6:20 NullKeyword - Wrong Structure: expected string!, but got null
 9:20 NullKeyword - Wrong Structure: expected string!, but got null
 10:20 NullKeyword - Wrong Structure: expected number!, but got null",
@@ -162,16 +182,17 @@ Object {
 
 exports[`MapValidator result & error error is an object non null fields: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "17:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: number!}, but got {f1: \\"some string\\", f3: 3}
-21:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: number!}, but got {f1: \\"some string\\", f2: 2, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object non null object with two required fields f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
+    "errors": "4:7 MapDefinition - No Error outcome defined",
+  },
+  "profile-provider#1": Object {
     "errors": "5:23 ObjectLiteral - Missing required field
 5:23 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null
@@ -184,15 +205,13 @@ Object {
 
 exports[`MapValidator result & error error is an object non null object with two required fields f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "9:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: number!}, but got {f1: \\"some string\\", f2: 2, f3: 3}",
-  },
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object one required and one not required field: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:23 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null
 11:20 NullKeyword - Wrong Structure: expected boolean!, but got null
@@ -206,16 +225,14 @@ Object {
 
 exports[`MapValidator result & error error is an object one required and one not required field: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "12:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: boolean!}, but got {f1: \\"some string\\", f3: 3}
-16:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: boolean!}, but got {f1: \\"some string\\", f2: false, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object one required field: f1 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:23 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null",
   },
@@ -224,15 +241,14 @@ Object {
 
 exports[`MapValidator result & error error is an object one required field: f1 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "8:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!}, but got {f1: \\"some string\\", f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object possibly null field f1 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "ObjectLiteral - Wrong Structure: expected string, but got {inner: 2}",
   },
 }
@@ -240,17 +256,14 @@ Object {
 
 exports[`MapValidator result & error error is an object possibly null field f1 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "10:23 ObjectLiteral - Wrong Object Structure: expected {f1: string}, but got {f1: null, f2: null}
-14:23 ObjectLiteral - Wrong Object Structure: expected {f1: string}, but got {f1: \\"some string\\", f2: 2}
-18:23 ObjectLiteral - Wrong Object Structure: expected {f1: string}, but got {f2: 2}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object possibly null fields: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "6:20 ArrayLiteralExpression - Wrong Structure: expected string, but got [\\"some\\", \\"key\\"]",
   },
 }
@@ -258,16 +271,14 @@ Object {
 
 exports[`MapValidator result & error error is an object possibly null fields: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "27:23 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number}, but got {f1: \\"some string\\", f3: 3}
-31:23 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number}, but got {f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is an object required fields: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:23 ObjectLiteral - Missing required field
 5:23 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null
@@ -284,24 +295,20 @@ Object {
 
 exports[`MapValidator result & error error is an object required fields: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "9:23 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: boolean!}, but got {f1: \\"some string\\", f2: true, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error error is conditioned then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "6:24 ObjectLiteralExpression - Wrong Structure: expected string, but got {}
-8:31 PrimitiveLiteral - Wrong Structure: expected {f1: {inner: string}}, but got \\"some string\\"",
-  },
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is PrimitiveTypeName then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:22 PrimitiveLiteral - Wrong Structure: expected NOTFOUND or BADREQUEST, but got \\"wrong\\"",
   },
 }
@@ -309,13 +316,16 @@ Object {
 
 exports[`MapValidator result & error result is PrimitiveTypeName then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is a list non null list with primitive or object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
+    "errors": "4:7 MapDefinition - No Result outcome defined",
+  },
+  "profile-provider#1": Object {
     "errors": "5:24 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [true, 2]
 6:24 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [true, 2, {}]
 7:24 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [[true]]",
@@ -325,13 +335,14 @@ Object {
 
 exports[`MapValidator result & error result is a list non null list with primitive or object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is a list non null primitive or object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}!], but got [null]
 6:24 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}!], but got [undefined]
 7:24 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}!], but got [true, 2]
@@ -343,13 +354,14 @@ Object {
 
 exports[`MapValidator result & error result is a list non null primitive or object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is a list non null primitive type or possibly null object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}], but got [true, 2]
 6:24 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}], but got [true, 2, {}]
 7:24 ArrayLiteralExpression - Wrong Structure: expected [boolean! | {}], but got [[true]]",
@@ -359,13 +371,14 @@ Object {
 
 exports[`MapValidator result & error result is a list non null primitive type or possibly null object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is a list non null primitive type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:25 NullKeyword - Wrong Structure: expected boolean!, but got null
 6:25 ObjectLiteralExpression - Wrong Structure: expected boolean, but got {}
 7:31 ObjectLiteralExpression - Wrong Structure: expected boolean, but got {}
@@ -377,13 +390,14 @@ Object {
 
 exports[`MapValidator result & error result is a list non null primitive type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is a list primitive or object type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [2]
 6:24 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [[true]]
 7:24 ArrayLiteralExpression - Wrong Structure: expected [boolean | {}], but got [true, 2, {}]",
@@ -393,13 +407,14 @@ Object {
 
 exports[`MapValidator result & error result is a list primitive or object type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is a list primitive type then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:25 FirstLiteralToken - Wrong Structure: expected boolean, but got 2
 6:25 ObjectLiteralExpression - Wrong Structure: expected boolean, but got {}",
   },
@@ -408,13 +423,22 @@ Object {
 
 exports[`MapValidator result & error result is a list primitive type then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
+}
+`;
+
+exports[`MapValidator result & error result is an object extra field then validation will pass with warnings 1`] = `
+Object {
+  "profile-provider#0": Object {
+    "warnings": "5:24 ObjectLiteral - Wrong Object Structure: expected {f1: string}, but got {f2: \\"what\\"}",
+  },
 }
 `;
 
 exports[`MapValidator result & error result is an object fields: f1, f2, where f2 is non null then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "7:20 NullKeyword - Wrong Structure: expected number!, but got null
 10:20 NullKeyword - Wrong Structure: expected number!, but got null",
     "warnings": "9:24 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number!}, but got {f2: null, f3: 3}",
@@ -424,16 +448,14 @@ Object {
 
 exports[`MapValidator result & error result is an object fields: f1, f2, where f2 is non null then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "24:24 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number!}, but got {f1: \\"some string\\", f2: 2, f3: 3}
-29:24 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number!}, but got {f2: 2, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object non null field f1 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "6:20 NullKeyword - Wrong Structure: expected string!, but got null
 9:20 ArrayLiteralExpression - Wrong Structure: expected string, but got [\\"some\\", \\"key\\"]",
   },
@@ -442,16 +464,14 @@ Object {
 
 exports[`MapValidator result & error result is an object non null field f1 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "10:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!}, but got {f1: \\"some string\\", f3: 3}
-14:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!}, but got {f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object non null fields: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "6:20 NullKeyword - Wrong Structure: expected string!, but got null
 9:20 NullKeyword - Wrong Structure: expected string!, but got null
 10:20 NullKeyword - Wrong Structure: expected number!, but got null",
@@ -461,16 +481,17 @@ Object {
 
 exports[`MapValidator result & error result is an object non null fields: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "17:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: number!}, but got {f1: \\"some string\\", f3: 3}
-21:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: number!}, but got {f1: \\"some string\\", f2: 2, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object non null object with two required fields f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
+    "errors": "4:7 MapDefinition - No Result outcome defined",
+  },
+  "profile-provider#1": Object {
     "errors": "5:24 ObjectLiteral - Missing required field
 5:24 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null
@@ -483,15 +504,13 @@ Object {
 
 exports[`MapValidator result & error result is an object non null object with two required fields f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "9:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: number!}, but got {f1: \\"some string\\", f2: 2, f3: 3}",
-  },
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object one required and one not required field: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null
 11:20 NullKeyword - Wrong Structure: expected boolean!, but got null
@@ -505,16 +524,14 @@ Object {
 
 exports[`MapValidator result & error result is an object one required and one not required field: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "12:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: boolean!}, but got {f1: \\"some string\\", f3: 3}
-16:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: boolean!}, but got {f1: \\"some string\\", f2: false, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object one required field: f1 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null",
   },
@@ -523,15 +540,14 @@ Object {
 
 exports[`MapValidator result & error result is an object one required field: f1 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "8:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!}, but got {f1: \\"some string\\", f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object possibly null field f1 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "ObjectLiteral - Wrong Structure: expected string, but got {inner: 2}",
   },
 }
@@ -539,13 +555,14 @@ Object {
 
 exports[`MapValidator result & error result is an object possibly null field f1 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object possibly null fields: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "6:20 ArrayLiteralExpression - Wrong Structure: expected string, but got [\\"some\\", \\"key\\"]",
   },
 }
@@ -553,16 +570,14 @@ Object {
 
 exports[`MapValidator result & error result is an object possibly null fields: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "27:24 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number}, but got {f1: \\"some string\\", f3: 3}
-31:24 ObjectLiteral - Wrong Object Structure: expected {f1: string, f2: number}, but got {f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is an object required fields: f1, f2 then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:24 ObjectLiteral - Missing required field
 5:24 ObjectLiteral - Missing required field
 8:20 NullKeyword - Wrong Structure: expected string!, but got null
@@ -579,23 +594,20 @@ Object {
 
 exports[`MapValidator result & error result is an object required fields: f1, f2 then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "9:24 ObjectLiteral - Wrong Object Structure: expected {f1: string!, f2: boolean!}, but got {f1: \\"some string\\", f2: true, f3: 3}",
-  },
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is conditioned then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "6:24 ObjectLiteralExpression - Wrong Structure: expected string, but got {}",
-  },
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is variable in different scopes then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:19 PrimitiveLiteral - Wrong Structure: expected string, but got false
 18:24 JessieExpression - Wrong Variable Structure: variable a.c expected string, but got false",
   },
@@ -604,7 +616,7 @@ Object {
 
 exports[`MapValidator result & error result is variable reassigned (object) then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "7:19 PrimitiveLiteral - Wrong Structure: expected {f1: string, f2: boolean}, but got \\"string\\"
 8:24 JessieExpression - Wrong Variable Structure: variable foo expected {f1: string, f2: boolean}, but got \\"string\\"",
   },
@@ -613,13 +625,17 @@ Object {
 
 exports[`MapValidator result & error result is variable reassigned (object) then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is variable reassigned (string) then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
+    "errors": "6:17 PrimitiveLiteral - Wrong Structure: expected string, but got false
+7:24 JessieExpression - Wrong Variable Structure: variable a expected string, but got false",
+  },
+  "profile-provider#1": Object {
     "errors": "6:19 PrimitiveLiteral - Wrong Structure: expected string, but got false
 7:24 JessieExpression - Wrong Variable Structure: variable a.b expected string, but got false",
   },
@@ -628,13 +644,14 @@ Object {
 
 exports[`MapValidator result & error result is variable reassigned (string) then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is variable referenced in outcome then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:13 ObjectLiteral - Wrong Structure: expected string, but got {c: \\"string\\"}
 6:24 JessieExpression - Wrong Variable Structure: variable a expected string, but got {c: \\"string\\"}",
   },
@@ -643,13 +660,13 @@ Object {
 
 exports[`MapValidator result & error result is variable referenced in outcome then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is variable using variable with string key then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:25 PrimitiveLiteral - Wrong Structure: expected string, but got false
 6:24 JessieExpression - Wrong Variable Structure: variable foo.bar.a expected string, but got false",
   },
@@ -658,13 +675,14 @@ Object {
 
 exports[`MapValidator result & error result is variable using variable with string key then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {},
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
 }
 `;
 
 exports[`MapValidator result & error result is variable wrong structure then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "5:19 PrimitiveLiteral - Wrong Structure: expected string, but got false
 6:24 JessieExpression - Wrong Variable Structure: variable a.b expected string, but got false",
   },
@@ -673,7 +691,7 @@ Object {
 
 exports[`MapValidator usecase-map compatibility missing maps then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "2:7 MapDocument - Map not found: \\"Test2\\"",
   },
 }
@@ -681,15 +699,13 @@ Object {
 
 exports[`MapValidator usecase-map compatibility multiple maps then validation will pass 1`] = `
 Object {
-  "profile-provider": Object {
-    "warnings": "2:7 MapDocument - Extra Maps Found: \\"Test\\", but got \\"Test, Test2\\"",
-  },
+  "profile-provider#0": Object {},
 }
 `;
 
-exports[`MapValidator usecase-map compatibility profile error missing then validation will pass 1`] = `
+exports[`MapValidator usecase-map compatibility profile error missing then validation will pass with warnings 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "warnings": "5:11 OutcomeStatement - Error Not Found: returning \\"some string\\", but there is no Error defined in usecase",
   },
 }
@@ -697,7 +713,7 @@ Object {
 
 exports[`MapValidator usecase-map compatibility profile input missing then validation will fail 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "errors": "7:25 PropertyAccessExpression - Input Not Found: input.something, but there is no Input defined in usecase
 9:40 PropertyAccessExpression - Input Not Found: input.some.variable, but there is no Input defined in usecase",
     "warnings": "11:11 OutcomeStatement - Result Not Found: returning output, but there is no Result defined in usecase",
@@ -705,9 +721,9 @@ Object {
 }
 `;
 
-exports[`MapValidator usecase-map compatibility profile result missing then validation will pass 1`] = `
+exports[`MapValidator usecase-map compatibility profile result missing then validation will pass with warnings 1`] = `
 Object {
-  "profile-provider": Object {
+  "profile-provider#0": Object {
     "warnings": "5:11 OutcomeStatement - Result Not Found: returning \\"some string\\", but there is no Result defined in usecase",
   },
 }
@@ -715,7 +731,7 @@ Object {
 
 exports[`MapValidator usecase-map compatibility wrong profile name then validation will fail 1`] = `
 Object {
-  "wrong-test": Object {
+  "wrong-test#0": Object {
     "errors": "1:1 MapHeader - Wrong Profile Name: expected \\"profile\\", but got \\"wrong\\"",
   },
 }
@@ -723,7 +739,7 @@ Object {
 
 exports[`MapValidator usecase-map compatibility wrong scope then validation will fail 1`] = `
 Object {
-  "test-test": Object {
+  "test-test#0": Object {
     "errors": "1:1 MapHeader - Wrong Scope: expected no scope in profile, but got starwars
 1:1 MapHeader - Wrong Profile Name: expected \\"profile\\", but got \\"test\\"",
   },
@@ -732,7 +748,7 @@ Object {
 
 exports[`MapValidator usecase-map compatibility wrong version then validation will fail 1`] = `
 Object {
-  "test-test": Object {
+  "test-test#0": Object {
     "errors": "1:1 MapHeader - Wrong Profile Name: expected \\"profile\\", but got \\"test\\"
 1:1 MapHeader - Version does not match: expected \\"1.0.0\\", but map requests \\"2.0.0\\"",
   },

--- a/src/interpreter/constructs.ts
+++ b/src/interpreter/constructs.ts
@@ -234,8 +234,6 @@ function getStructureProperty(
   structure: ObjectStructure | ListStructure,
   property: string
 ): StructureType | undefined {
-  console.debug('DEBUG', 'getting property', property, 'in', structure);
-
   if (isObjectStructure(structure)) {
     return structure.fields?.[property];
   }

--- a/src/interpreter/constructs.ts
+++ b/src/interpreter/constructs.ts
@@ -5,6 +5,7 @@ import { UseCaseSlotType } from '.';
 import { ValidationIssue } from './issue';
 import {
   ArrayCollection,
+  ListStructure,
   ObjectStructure,
   StructureType,
 } from './profile-output';
@@ -23,8 +24,7 @@ import {
 import {
   findTypescriptIdentifier,
   findTypescriptProperty,
-  getVariableName,
-  validateObjectStructure,
+  getVariableName
 } from './utils';
 
 export type TypescriptIdentifier =
@@ -229,32 +229,103 @@ function returnIssue(
       };
 }
 
-function getFieldStructure(
-  property: string,
-  node: ts.LeftHandSideExpression,
-  objectStructure: ObjectStructure
+const LIST_INDEX_REGEX = /^[0-9]+$/;
+function getStructureProperty(
+  structure: ObjectStructure | ListStructure,
+  property: string
 ): StructureType | undefined {
-  if (ts.isIdentifier(node)) {
-    if (!objectStructure.fields) {
-      throw new Error('Validated object structure does not contain fields');
-    }
+  console.debug('DEBUG', 'getting property', property, 'in', structure);
 
-    return objectStructure.fields[property];
-  } else if (ts.isPropertyAccessExpression(node)) {
-    let structure = validateObjectStructure(node, objectStructure);
+  if (isObjectStructure(structure)) {
+    return structure.fields?.[property];
+  }
 
-    if (structure && isNonNullStructure(structure)) {
-      structure = structure.value;
-    }
+  // spec says arrays always have length property 
+  if (property === 'length') {
+    return {
+      kind: 'PrimitiveStructure',
+      type: 'number',
+    };
+  }
 
-    if (!structure || !isObjectStructure(structure) || !structure.fields) {
-      return undefined;
-    }
-
-    return structure.fields[property];
+  // arrays can be indexed using numbers
+  if (LIST_INDEX_REGEX.test(property)) {
+    return structure.value;
   }
 
   return undefined;
+}
+
+function getAccessNodeProperty(
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression
+): { kind: 'static', property: string } | { kind: 'dynamic' } {
+  if (ts.isPropertyAccessExpression(node)) {
+    return { kind: 'static', property: node.name.text };
+  }
+
+  if (ts.isElementAccessExpression(node)) {
+    if (
+      ts.isNumericLiteral(node.argumentExpression)
+      || ts.isStringLiteral(node.argumentExpression)
+    ) {
+      return { kind: 'static', property: node.argumentExpression.text };
+    }
+
+    if (node.argumentExpression.kind === ts.SyntaxKind.TrueKeyword) {
+      return { kind: 'static', property: 'true' };
+    }
+    if (node.argumentExpression.kind === ts.SyntaxKind.FalseKeyword) {
+      return { kind: 'static', property: 'false' };
+    }
+  }
+
+  return { kind: 'dynamic' };
+}
+
+// Assumes `structure` is the base object which is being accessed
+function accessStructure(
+  structure: ObjectStructure | ListStructure,
+  accessNode: ts.PropertyAccessExpression | ts.ElementAccessExpression
+): StructureType | undefined {
+  // note that this will be in reverse order (last property to access first)
+  const propertyChain: string[] = [];
+
+  let currentNode: ts.LeftHandSideExpression = accessNode;
+  while (ts.isPropertyAccessExpression(currentNode) || ts.isElementAccessExpression(currentNode)) {
+    const property = getAccessNodeProperty(currentNode);
+
+    if (property.kind === 'dynamic') {
+      // TODO-future: This would attempt to resolve the dynamic property
+      return undefined;
+    }
+
+    propertyChain.push(property.property);
+    currentNode = currentNode.expression;
+  }
+  propertyChain.reverse();
+
+  let currentStructure: StructureType | undefined = structure;
+  for (const property of propertyChain) {
+    if (currentStructure === undefined) {
+      break;
+    }
+
+    // unpack non-nulls
+    // TODO: what to do with unions?
+    if (isNonNullStructure(currentStructure)) {
+      currentStructure = currentStructure.value;
+    }
+
+    if (!isObjectStructure(currentStructure) && !isListStructure(currentStructure)) {
+      // TODO: Or return a more descriptive error here to allow better reporting?
+      currentStructure = undefined;
+      break;
+    }
+
+    currentStructure = getStructureProperty(currentStructure, property);
+  }
+
+  return currentStructure;
 }
 
 export const RETURN_CONSTRUCTS: {
@@ -639,12 +710,7 @@ export const RETURN_CONSTRUCTS: {
           },
         };
 
-        const property = node.name.text;
-        const fieldValue = getFieldStructure(
-          property,
-          node.expression,
-          inputStructure
-        );
+        const fieldValue = accessStructure(inputStructure, node);
 
         if (!fieldValue) {
           return returnIssue(issue, true, false, isOutcomeWithCondition);
@@ -706,12 +772,7 @@ export const RETURN_CONSTRUCTS: {
           },
         };
 
-        const property = (node.argumentExpression as ts.Identifier).text;
-        const fieldValue = getFieldStructure(
-          property,
-          node.expression,
-          inputStructure
-        );
+        const fieldValue = accessStructure(inputStructure, node);
 
         if (!fieldValue) {
           return returnIssue(issue, true, false, isOutcomeWithCondition);

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -34,7 +34,6 @@ import {
   StructureType,
   VersionStructure,
 } from './profile-output';
-import { isObjectStructure } from './profile-output.utils';
 
 export function composeVersion(version: VersionStructure): string {
   return (
@@ -383,52 +382,6 @@ export const REDUDANT_EXPRESSION_CHARACTERS_REGEX = /['"[\]]/g;
 
 export function replaceRedudantCharacters(text: string): string {
   return text.replace(REDUDANT_EXPRESSION_CHARACTERS_REGEX, '');
-}
-
-export function validateObjectStructure(
-  node: TypescriptIdentifier,
-  structure: ObjectStructure
-): StructureType | undefined {
-  if (ts.isIdentifier(node)) {
-    return structure;
-  }
-
-  let expression: ts.LeftHandSideExpression;
-  let name: ts.PrivateIdentifier | ts.Expression;
-
-  if (ts.isElementAccessExpression(node)) {
-    expression = node.expression;
-    name = node.argumentExpression;
-  } else {
-    expression = node.expression;
-    name = node.name;
-  }
-
-  const key = replaceRedudantCharacters(name.getText());
-  let outputStructure: StructureType | undefined;
-
-  if (
-    ts.isPropertyAccessExpression(expression) ||
-    ts.isElementAccessExpression(expression)
-  ) {
-    outputStructure = validateObjectStructure(expression, structure);
-  } else if (ts.isIdentifier(expression)) {
-    if (!structure.fields) {
-      return undefined;
-    }
-
-    return structure.fields[key];
-  }
-
-  if (
-    !outputStructure ||
-    !isObjectStructure(outputStructure) ||
-    !outputStructure.fields
-  ) {
-    return undefined;
-  }
-
-  return outputStructure.fields[key];
 }
 
 export function findTypescriptIdentifier(name: string, node: ts.Node): boolean {


### PR DESCRIPTION
## Description
Rewritten part of validator responsible from resolving property accessors - it is now streamlined (no duplicate logic) and can handle arrays/lists correctly.

Note that this part of the validator deserves more attention to handle rebound variables.

## Motivation and Context
The validator was reporting a very confusing (and wrong) error when accessing lists on the input object

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
