### PR TITLE
fix: ObjectStructure fields not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Script sublexer infinite loop on some invalid scripts (nesting ignoring EOF token)
 - Validator now properly handles list property access
 
+### Changed
+- **BREAKING CHANGE:** property `fields` in `ObjectStructure` is no longer optional
+
 ## [1.2.0] - 2022-04-13
 ### Added
 - `EnumStructure` added name field

--- a/src/interpreter/map-validator.test.ts
+++ b/src/interpreter/map-validator.test.ts
@@ -157,6 +157,40 @@ describe('MapValidator', () => {
     });
 
     describe('result is an object', () => {
+      describe('empty object', () => {
+        const profileAst = parseProfileFromSource(
+          `usecase Test {
+            result {}    
+          }`
+        );
+        const mapAst1 = parseMapFromSource(
+          `map Test {
+            map result {}
+          }`
+        );
+
+        // TODO: complete this
+        // const mapAst2 = parseMapFromSource(
+        //   `map Test {
+        //     map result {
+        //       f2 = "what"
+        //     }
+        //   }`
+        // );
+
+        validWithWarnings(
+          profileAst,
+          [
+            mapAst1,
+            // mapAst2
+          ],
+          [
+            '',
+            // 'ObjectLiteral - Wrong Object Structure: expected {}, but got {f2: "what"}',
+          ]
+        );
+      });
+
       describe('extra field', () => {
         const profileAst = parseProfileFromSource(
           `usecase Test {

--- a/src/interpreter/map-validator.test.ts
+++ b/src/interpreter/map-validator.test.ts
@@ -169,24 +169,20 @@ describe('MapValidator', () => {
           }`
         );
 
-        // TODO: complete this
-        // const mapAst2 = parseMapFromSource(
-        //   `map Test {
-        //     map result {
-        //       f2 = "what"
-        //     }
-        //   }`
-        // );
+        const mapAst2 = parseMapFromSource(
+          `map Test {
+            map result {
+              f2 = "what"
+            }
+          }`
+        );
 
         validWithWarnings(
           profileAst,
+          [mapAst1, mapAst2],
+          [''],
           [
-            mapAst1,
-            // mapAst2
-          ],
-          [
-            '',
-            // 'ObjectLiteral - Wrong Object Structure: expected {}, but got {f2: "what"}',
+            'ObjectLiteral - Wrong Object Structure: expected {}, but got {f2: "what"}',
           ]
         );
       });

--- a/src/interpreter/map-validator.ts
+++ b/src/interpreter/map-validator.ts
@@ -595,11 +595,6 @@ export class MapValidator implements MapAstVisitor {
 
     // unpack here, otherwise TS fails to infer that is cannot be undefined
     const objectStructure = validationResult.objectStructure;
-    if (objectStructure.fields === undefined) {
-      throw new Error(
-        'Validated object structure is not defined or does not contain fields'
-      );
-    }
 
     // all fields
     const profileFields = Object.entries(objectStructure.fields);

--- a/src/interpreter/profile-io-analyzer.advanced.test.ts
+++ b/src/interpreter/profile-io-analyzer.advanced.test.ts
@@ -43,13 +43,11 @@ describe('ProfileValidator Advanced', () => {
         usecases: [
           {
             useCaseName: 'Test',
-            input: {
-              kind: 'ObjectStructure',
-            },
+            input: { kind: 'ObjectStructure', fields: {} },
             result: {
               kind: 'UnionStructure',
               types: [
-                { kind: 'ObjectStructure' },
+                { kind: 'ObjectStructure', fields: {} },
                 {
                   kind: 'NonNullStructure',
                   value: {
@@ -167,6 +165,7 @@ describe('ProfileValidator Advanced', () => {
             useCaseName: 'Test',
             input: {
               kind: 'ObjectStructure',
+              fields: {},
             },
             result: {
               kind: 'UnionStructure',
@@ -221,6 +220,7 @@ describe('ProfileValidator Advanced', () => {
             useCaseName: 'Test',
             input: {
               kind: 'ObjectStructure',
+              fields: {},
             },
             result: {
               kind: 'UnionStructure',

--- a/src/interpreter/profile-io-analyzer.test.ts
+++ b/src/interpreter/profile-io-analyzer.test.ts
@@ -323,6 +323,7 @@ describe('ProfileIOAnalyzer', () => {
             useCaseName: 'Test',
             result: {
               kind: 'ObjectStructure',
+              fields: {}
             },
           },
         ],

--- a/src/interpreter/profile-io-analyzer.ts
+++ b/src/interpreter/profile-io-analyzer.ts
@@ -234,7 +234,7 @@ export class ProfileIOAnalyzer implements ProfileAstVisitor {
 
         return obj;
       },
-      { kind: 'ObjectStructure' }
+      { kind: 'ObjectStructure', fields: {} }
     );
   }
 

--- a/src/interpreter/profile-output.ts
+++ b/src/interpreter/profile-output.ts
@@ -63,7 +63,7 @@ export interface ListStructure extends Structure {
  */
 export interface ObjectStructure extends Structure, DocumentedStructure {
   kind: 'ObjectStructure';
-  fields?: ObjectCollection;
+  fields: ObjectCollection;
 }
 
 /**


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->
`ObjectStructure` contains optional property `fields` which anyway need to be always present, this PR makes them non-optional and updates files accordingly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unexpected error when using empty object result in profile.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
