### PR TITLE
Fix enum validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `expression` to `getPath`
+- `getAccessKey` returns error for dynamic expressions
+- Added `isAccessKeyError` and `isAccessKey`
+
+### Changed
+- Renamed `getVariableName` to `getAccessKey`
 
 ## [2.0.0-rc.1] - 2022-09-07
 ### Added

--- a/src/interpreter/__snapshots__/map-validator.test.ts.snap
+++ b/src/interpreter/__snapshots__/map-validator.test.ts.snap
@@ -593,16 +593,7 @@ exports[`MapValidator result & error result is an object required field enum f1 
 Object {
   "profile-provider#0": Object {},
   "profile-provider#1": Object {},
-  "profile-provider#2": Object {
-    "errors": "5:24 ObjectLiteralExpression - Wrong Structure: expected unknown or ready, but got {
-              ready: \\"ready\\",
-              unknown: \\"unknown\\",
-            }
-14:20 JessieExpression - Wrong Variable Structure: variable mapState expected unknown or ready!, but got {
-              ready: \\"ready\\",
-              unknown: \\"unknown\\",
-            }",
-  },
+  "profile-provider#2": Object {},
 }
 `;
 

--- a/src/interpreter/__snapshots__/map-validator.test.ts.snap
+++ b/src/interpreter/__snapshots__/map-validator.test.ts.snap
@@ -575,6 +575,37 @@ Object {
 }
 `;
 
+exports[`MapValidator result & error result is an object required field enum f1 then validation will fail 1`] = `
+Object {
+  "profile-provider#0": Object {
+    "errors": "5:24 ObjectLiteral - Missing required field
+7:20 NullKeyword - Wrong Structure: expected unknown or ready!, but got null
+9:24 ObjectLiteral - Missing required field
+13:20 NullKeyword - Wrong Structure: expected unknown or ready!, but got null
+16:20 PrimitiveLiteral - Wrong Structure: expected unknown or ready, but got \\"some string\\"
+19:20 PrimitiveLiteral - Wrong Structure: expected unknown or ready, but got \\"some string\\"",
+    "warnings": "9:24 ObjectLiteral - Wrong Object Structure: expected {f1: unknown or ready!}, but got {f2: null}",
+  },
+}
+`;
+
+exports[`MapValidator result & error result is an object required field enum f1 then validation will pass 1`] = `
+Object {
+  "profile-provider#0": Object {},
+  "profile-provider#1": Object {},
+  "profile-provider#2": Object {
+    "errors": "5:24 ObjectLiteralExpression - Wrong Structure: expected unknown or ready, but got {
+              ready: \\"ready\\",
+              unknown: \\"unknown\\",
+            }
+14:20 JessieExpression - Wrong Variable Structure: variable mapState expected unknown or ready!, but got {
+              ready: \\"ready\\",
+              unknown: \\"unknown\\",
+            }",
+  },
+}
+`;
+
 exports[`MapValidator result & error result is an object required fields: f1, f2 then validation will fail 1`] = `
 Object {
   "profile-provider#0": Object {

--- a/src/interpreter/map-validator.test.ts
+++ b/src/interpreter/map-validator.test.ts
@@ -556,6 +556,71 @@ describe('MapValidator', () => {
         invalid(profileAst, [mapAst3]);
       });
 
+      describe.only('required field enum f1', () => {
+        const profileAst = parseProfileFromSource(
+          `usecase Test {
+            result {
+              f1! State!
+            }
+          }
+          model State enum {
+            unknown
+            ready
+          }`
+        );
+
+        const mapAst1 = parseMapFromSource('map Test {}');
+        const mapAst2 = parseMapFromSource(
+          `map Test {
+            map result {
+              f1 = "ready"
+            }
+            map result {
+              f1 = "unknown"
+            }
+          }`
+        );
+        const mapAst3 = parseMapFromSource(
+          `map Test {
+            mapState = {
+              ready: "ready",
+              unknown: "unknown",
+            }
+
+            map result {
+              f1 = mapState["ready"]
+            }
+            map result {
+              f1 = mapState[body.state]
+            }
+          }`
+        );
+
+        const mapAst4 = parseMapFromSource(
+          `map Test {
+            map result {}
+            map result {
+              f1 = null
+            }
+            map result {
+              f2 = null
+            }
+            map result {
+              f1 = null
+            }
+            map result {
+              f1 = "some string"
+            }
+            map result {
+              f1 = "some string"
+            } 
+          }`
+        );
+
+        valid(profileAst, [mapAst1, mapAst2, mapAst3]);
+        invalid(profileAst, [mapAst4]);
+      });
+
       describe('non null object with two required fields f1, f2', () => {
         const profileAst = parseProfileFromSource(
           `usecase Test {

--- a/src/interpreter/map-validator.test.ts
+++ b/src/interpreter/map-validator.test.ts
@@ -556,7 +556,7 @@ describe('MapValidator', () => {
         invalid(profileAst, [mapAst3]);
       });
 
-      describe.only('required field enum f1', () => {
+      describe('required field enum f1', () => {
         const profileAst = parseProfileFromSource(
           `usecase Test {
             result {

--- a/src/interpreter/map-validator.ts
+++ b/src/interpreter/map-validator.ts
@@ -49,8 +49,8 @@ import {
 import { isNonNullStructure, isScalarStructure } from './profile-output.utils';
 import {
   findTypescriptIdentifier,
+  getAccessKey,
   getOutcomes,
-  getVariableName,
   mergeVariables,
   validateObjectLiteral,
   validatePrimitiveLiteral,
@@ -91,7 +91,7 @@ export class MapValidator implements MapAstVisitor {
   constructor(
     private readonly mapAst: MapASTNode,
     private readonly profileOutput: ProfileOutput
-  ) {}
+  ) { }
 
   validate(): ValidationResult {
     this.visit(this.mapAst);
@@ -534,8 +534,11 @@ export class MapValidator implements MapAstVisitor {
         continue;
       }
 
-      const variableName = getVariableName(jessieNode);
-      const variable = this.variables[variableName];
+      const accessKey = getAccessKey(jessieNode);
+      let variable;
+      if (accessKey.kind === 'AccessKey') {
+        variable = this.variables[accessKey.key];
+      }
 
       if (variable !== undefined) {
         this.currentStructure = type;
@@ -547,7 +550,7 @@ export class MapValidator implements MapAstVisitor {
             kind: 'wrongVariableStructure',
             context: {
               path: this.getPath(node),
-              name: variableName,
+              name: accessKey.kind === 'AccessKey' ? accessKey.key : accessKey.message,
               expected: type,
               actual: variable,
             },

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -417,7 +417,7 @@ export function findTypescriptProperty(name: string, node: ts.Node): boolean {
 }
 
 export function getTypescriptIdentifierName(node: ts.Node): string {
-  if (ts.isIdentifier(node)) {
+  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) {
     return node.text;
   }
 
@@ -451,10 +451,9 @@ export function getVariableName(
   }
 
   if (ts.isElementAccessExpression(node)) {
-    const nodeName = (node.argumentExpression as ts.Identifier).text;
-    name = name !== '' ? `${nodeName}.${name}` : nodeName;
-
-    return getVariableName(node.expression, name);
+    return name !== ''
+    ? `${getTypescriptIdentifierName(node)}.${name}`
+    : getTypescriptIdentifierName(node);
   }
 
   return 'undefined';

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -452,8 +452,8 @@ export function getVariableName(
 
   if (ts.isElementAccessExpression(node)) {
     return name !== ''
-    ? `${getTypescriptIdentifierName(node)}.${name}`
-    : getTypescriptIdentifierName(node);
+      ? `${getTypescriptIdentifierName(node)}.${name}`
+      : getTypescriptIdentifierName(node);
   }
 
   return 'undefined';

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -416,8 +416,10 @@ export function findTypescriptProperty(name: string, node: ts.Node): boolean {
   return false;
 }
 
-export function getTypescriptIdentifierName(node: ts.Node): string {
-  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) {
+export function getVariableName(
+  node: TypescriptIdentifier,
+): string {
+  if (ts.isIdentifier(node)) {
     return node.text;
   }
 
@@ -429,31 +431,6 @@ export function getTypescriptIdentifierName(node: ts.Node): string {
     return replaceRedudantCharacters(
       `${node.expression.getText()}.${node.argumentExpression.getText()}`
     );
-  }
-
-  return 'undefined';
-}
-
-export function getVariableName(
-  node: TypescriptIdentifier | ts.LeftHandSideExpression,
-  name?: string
-): string {
-  name = name ? replaceRedudantCharacters(name) : '';
-
-  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) {
-    return name !== '' ? `${node.text}.${name}` : node.text;
-  }
-
-  if (ts.isPropertyAccessExpression(node)) {
-    name = name !== '' ? `${node.name.text}.${name}` : node.name.text;
-
-    return getVariableName(node.expression, name);
-  }
-
-  if (ts.isElementAccessExpression(node)) {
-    return name !== ''
-      ? `${getTypescriptIdentifierName(node)}.${name}`
-      : getTypescriptIdentifierName(node);
   }
 
   return 'undefined';


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

This PR changes how variables are accessed in interpreter (validator).

Right now, we stop and return error for dynamic expressions, but we could be able to return also `AccessKeypartial` to validate at least part of the expressions.

This build on #103 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Validation enums doesn't work correctly because property and element access expressions were not handled properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
