### PR TITLE
doc: fix changelog after releasing rc as stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Script sublexer, script compiler and syntax rules now produce debug logs for debugging
+- Compatibility check of AST metadata into validators
+- `safety` field to `UseCaseStructure`
 - Added `expression` to `getPath`
 - `getAccessKey` returns error for dynamic expressions
 - Added `isAccessKeyError` and `isAccessKey`
 
 ### Changed
-- Renamed `getVariableName` to `getAccessKey`
-
-## [2.0.0-rc.1] - 2022-09-07
-### Added
-- Script sublexer, script compiler and syntax rules now produce debug logs for debugging
-- Compatibility check of AST metadata into validators
-- `safety` field to `UseCaseStructure`
-
-### Changed
 - **BREAKING CHANGE:** property `fields` in `ObjectStructure` is no longer optional
+- Renamed `getVariableName` to `getAccessKey`
 
 ### Fixed
 - Script sublexer infinite loop on some invalid scripts (nesting ignoring EOF token)


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

Moves entries from RC.1 to unreleased to be part of 2.0.0 stable release

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`rc.2` was accidentally released as stable, which created a new entry in changelog for RC version. But we don't want to have RC versions in changelog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
