### PR TITLE
Fix/profile header version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Profile header rule now strictly requires full semver version in version field, as the spec defines
+
 ## [2.0.0] - 2022-11-08
 ### Added
 - Script sublexer, script compiler and syntax rules now produce debug logs for debugging

--- a/src/language/syntax/rules/profile/profile.test.ts
+++ b/src/language/syntax/rules/profile/profile.test.ts
@@ -1484,7 +1484,7 @@ describe('profile syntax rules', () => {
 
         tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'version' }),
         tesTok({ kind: LexerTokenKind.OPERATOR, operator: '=' }),
-        tesTok({ kind: LexerTokenKind.STRING, string: '11.12' }),
+        tesTok({ kind: LexerTokenKind.STRING, string: '11.12.3' }),
       ];
       const stream = new ArrayLexerStream(tokens);
 
@@ -1498,7 +1498,7 @@ describe('profile syntax rules', () => {
             version: {
               major: 11,
               minor: 12,
-              patch: 0,
+              patch: 3,
             },
             documentation: {
               title: 'Title',
@@ -1522,7 +1522,7 @@ describe('profile syntax rules', () => {
 
         tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'version' }),
         tesTok({ kind: LexerTokenKind.OPERATOR, operator: '=' }),
-        tesTok({ kind: LexerTokenKind.STRING, string: '1' }),
+        tesTok({ kind: LexerTokenKind.STRING, string: '1.2.3' }),
 
         tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'model' }),
         tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'model1' }),
@@ -1559,8 +1559,8 @@ describe('profile syntax rules', () => {
                 name: 'profile',
                 version: {
                   major: 1,
-                  minor: 0,
-                  patch: 0,
+                  minor: 2,
+                  patch: 3,
                 },
               },
               tokens[1],
@@ -1629,6 +1629,23 @@ describe('profile syntax rules', () => {
           tokens[17]
         )
       );
+    });
+
+    it('should require full version in profile header', () => {
+      const tokens: ReadonlyArray<LexerToken> = [
+        tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'name' }),
+        tesTok({ kind: LexerTokenKind.OPERATOR, operator: '=' }),
+        tesTok({ kind: LexerTokenKind.STRING, string: 'scope/profile' }),
+
+        tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'version' }),
+        tesTok({ kind: LexerTokenKind.OPERATOR, operator: '=' }),
+        tesTok({ kind: LexerTokenKind.STRING, string: '1.2' }),
+      ];
+      const stream = new ArrayLexerStream(tokens);
+
+      const rule = rules.PROFILE_HEADER;
+
+      expect(rule.tryMatch(stream)).not.toBeAMatch();
     });
   });
 

--- a/src/language/syntax/rules/profile/profile.ts
+++ b/src/language/syntax/rules/profile/profile.ts
@@ -22,8 +22,8 @@ import {
   UseCaseSlotDefinitionNode,
 } from '@superfaceai/ast';
 
+import { ProfileVersion } from '../../../../common';
 import { parseDocumentId } from '../../../../common/document/parser';
-import { VersionRange } from '../../../../common/document/version';
 import { PARSED_AST_VERSION, PARSED_VERSION } from '../../../../metadata';
 import { IdentifierTokenData, LexerTokenKind } from '../../../lexer/token';
 import {
@@ -568,14 +568,14 @@ const PROFILE_VERSION = SyntaxRule.followedBy(
     } & HasLocation
   >(version => {
     try {
-      const parsedVersion = VersionRange.fromString(version.data.string);
+      const parsedVersion = ProfileVersion.fromString(version.data.string);
 
       return {
         kind: 'match',
         value: {
           major: parsedVersion.major,
-          minor: parsedVersion.minor ?? 0,
-          patch: parsedVersion.patch ?? 0,
+          minor: parsedVersion.minor,
+          patch: parsedVersion.patch,
           label: parsedVersion.label,
           location: version.location,
         },
@@ -583,7 +583,7 @@ const PROFILE_VERSION = SyntaxRule.followedBy(
     } catch (error) {
       return { kind: 'nomatch' };
     }
-  }, 'semver version')
+  }, 'semver version in format `<major>.<minor>.<patch>`')
 ).map(([keyword, op, version]) => {
   return {
     version: {


### PR DESCRIPTION
## Description
Fixes profile header parser rule so that it no longer accepts incomplete versions (version ranges)

## Motivation and Context
Previously it was allowed to specify a version in profile such as "1.2" or "1" and the others fields would default to 0, however this was never allowed by the spec.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
