### PR TITLE
Add `None` parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added syntax rule for `None` literal
 
 ### Fixed
 - Profile header rule now strictly requires full semver version in version field, as the spec defines

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-jest": "^27.1.3"
   },
   "dependencies": {
-    "@superfaceai/ast": "^1.2.0",
+    "@superfaceai/ast": "1.3.0-rc.0",
     "@types/debug": "^4.1.5",
     "debug": "^4.3.3",
     "typescript": "^4"

--- a/src/interpreter/example-validator.test.ts
+++ b/src/interpreter/example-validator.test.ts
@@ -99,5 +99,25 @@ describe('ExampleValidator', () => {
         'ComlinkPrimitiveLiteral - Wrong Structure: expected [boolean | number], but got "string"',
       ]);
     });
+
+    it('none', () => {
+      const profileAst = parseProfileFromSource(
+        `usecase Test {
+              result {
+                  f1 string!
+              }
+  
+              example fail {
+                  result {
+                      f1 = None
+                  }
+              }
+          }`
+      );
+
+      expect(profileAst).not.toBeValidExample([
+        'ComlinkNoneLiteral - Wrong Structure: expected string!, but got None',
+      ]);
+    });
   });
 });

--- a/src/interpreter/example-validator.ts
+++ b/src/interpreter/example-validator.ts
@@ -2,6 +2,7 @@ import {
   ComlinkAssignmentNode,
   ComlinkListLiteralNode,
   ComlinkLiteralNode,
+  ComlinkNoneLiteralNode,
   ComlinkObjectLiteralNode,
   ComlinkPrimitiveLiteralNode,
   EnumDefinitionNode,
@@ -40,6 +41,7 @@ import {
 } from '.';
 import {
   validateListLiteral,
+  validateNoneLiteral,
   validateObjectLiteral,
   validatePrimitiveLiteral,
 } from './utils';
@@ -102,6 +104,8 @@ export class ExampleValidator implements ProfileAstVisitor {
         return this.visitComlinkObjectLiteralNode(node);
       case 'ComlinkAssignment':
         return this.visitComlinkAssignmentNode(node);
+      case 'ComlinkNoneLiteral':
+        return this.visitComlinkNoneLiteralNode(node);
       // UNUSED
       case 'FieldDefinition':
         return this.visitFieldDefinitionNode(node);
@@ -214,6 +218,25 @@ export class ExampleValidator implements ProfileAstVisitor {
     assertDefinedStructure(this.currentStructure);
 
     const { isValid } = validatePrimitiveLiteral(this.currentStructure, node);
+
+    if (!isValid) {
+      this.errors.push({
+        kind: 'wrongStructure',
+        context: {
+          path: this.getPath(node),
+          expected: this.currentStructure,
+          actual: node,
+        },
+      });
+    }
+
+    return isValid;
+  }
+
+  visitComlinkNoneLiteralNode(node: ComlinkNoneLiteralNode): boolean {
+    assertDefinedStructure(this.currentStructure);
+
+    const { isValid } = validateNoneLiteral(this.currentStructure);
 
     if (!isValid) {
       this.errors.push({

--- a/src/interpreter/profile-io-analyzer.ts
+++ b/src/interpreter/profile-io-analyzer.ts
@@ -1,6 +1,7 @@
 import {
   ComlinkAssignmentNode,
   ComlinkListLiteralNode,
+  ComlinkNoneLiteralNode,
   ComlinkObjectLiteralNode,
   ComlinkPrimitiveLiteralNode,
   DocumentedNode,
@@ -141,6 +142,8 @@ export class ProfileIOAnalyzer implements ProfileAstVisitor {
         return this.visitComlinkObjectLiteralNode(node);
       case 'ComlinkAssignment':
         return this.visitComlinkAssignmentNode(node);
+      case 'ComlinkNoneLiteral':
+        return this.visitComlinkNoneLiteralNode(node);
       default:
         assertUnreachable(node);
     }
@@ -325,6 +328,10 @@ export class ProfileIOAnalyzer implements ProfileAstVisitor {
   }
 
   visitComlinkAssignmentNode(_node: ComlinkAssignmentNode): void {
+    throw new Error('Not Implemented');
+  }
+
+  visitComlinkNoneLiteralNode(_node: ComlinkNoneLiteralNode): void {
     throw new Error('Not Implemented');
   }
 

--- a/src/interpreter/utils.ts
+++ b/src/interpreter/utils.ts
@@ -94,6 +94,8 @@ function formatLiteral(
     case 'PrimitiveLiteral':
     case 'ComlinkPrimitiveLiteral':
       return formatPrimitive(literal.value);
+    case 'ComlinkNoneLiteral':
+      return 'None';
     case 'ObjectLiteral':
     case 'ComlinkObjectLiteral':
       return `{${literal.fields.map(formatLiteral).join(', ')}}`;
@@ -267,6 +269,14 @@ export function validateListLiteral(
   }
 
   return { isValid: false };
+}
+
+export function validateNoneLiteral(structure: StructureType): { isValid: boolean } {
+  if (structure.kind === 'NonNullStructure') {
+    return { isValid: false };
+  }
+
+  return { isValid: true }
 }
 
 export function getOutcomes(

--- a/src/language/language.test.ts
+++ b/src/language/language.test.ts
@@ -467,7 +467,10 @@ describe('profile', () => {
   it('should parse profile with examples', () => {
     const input = `
     usecase Foo {
-      input { f! string! }
+      input {
+        f! string!
+        fn string
+      }
       result number
       error enum {
         FORBIDDEN_WORD
@@ -478,6 +481,7 @@ describe('profile', () => {
         input {
           "hello has 5 letters"
           f = "hello"
+          fn = None
         }
         result 5
         // TODO: do we want this? async result undefined
@@ -531,6 +535,13 @@ describe('profile', () => {
                       title: 'hello has 5 letters',
                     },
                   },
+                  {
+                    kind: 'ComlinkAssignment',
+                    key: ['fn'],
+                    value: {
+                      kind: 'ComlinkNoneLiteral'
+                    }
+                  }
                 ],
               },
             },

--- a/src/language/lexer/lexer.test.ts
+++ b/src/language/lexer/lexer.test.ts
@@ -348,7 +348,7 @@ describe('lexer', () => {
     test('identifiers', () => {
       const lexer = new Lexer(
         new Source(
-          'ident my fier pls usecaseNOT modelout boolean b00lean a123456789_0'
+          'ident my fier pls usecaseNOT modelout boolean b00lean a123456789_0 None'
         )
       );
       const expectedTokens: (LexerTokenData | IdentifierValue)[] = [
@@ -362,6 +362,7 @@ describe('lexer', () => {
         'boolean',
         'b00lean',
         'a123456789_0',
+        'None',
         { kind: LexerTokenKind.SEPARATOR, separator: 'EOF' },
       ];
 

--- a/src/language/lexer/token.ts
+++ b/src/language/lexer/token.ts
@@ -179,7 +179,7 @@ export class LexerToken {
     /** Data of the token. */
     readonly data: LexerTokenData,
     readonly location: LocationSpan
-  ) {}
+  ) { }
 
   isSOF(): boolean {
     return (

--- a/src/language/syntax/rules/profile/literal.ts
+++ b/src/language/syntax/rules/profile/literal.ts
@@ -2,6 +2,7 @@ import {
   ComlinkAssignmentNode,
   ComlinkListLiteralNode,
   ComlinkLiteralNode,
+  ComlinkNoneLiteralNode,
   ComlinkObjectLiteralNode,
   ComlinkPrimitiveLiteralNode,
 } from '@superfaceai/ast';
@@ -90,8 +91,20 @@ export const COMLINK_LIST_LITERAL: SyntaxRule<
   }
 );
 
+export const COMLINK_NONE_LITERAL: SyntaxRule<
+  WithLocation<ComlinkNoneLiteralNode>
+> = SyntaxRule.identifier('None').map(
+  (match): WithLocation<ComlinkNoneLiteralNode> => {
+    return {
+      kind: 'ComlinkNoneLiteral',
+      location: match.location,
+    };
+  }
+);
+
 export const COMLINK_LITERAL = SyntaxRule.or(
   COMLINK_PRIMITIVE_LITERAL,
+  COMLINK_NONE_LITERAL,
   COMLINK_OBJECT_LITERAL,
   COMLINK_LIST_LITERAL
 );

--- a/src/language/syntax/rules/profile/profile.test.ts
+++ b/src/language/syntax/rules/profile/profile.test.ts
@@ -1669,6 +1669,24 @@ describe('profile syntax rules', () => {
       );
     });
 
+    it('should parse none literal', () => {
+      const tokens: ReadonlyArray<LexerToken> = [
+        tesTok({ kind: LexerTokenKind.IDENTIFIER, identifier: 'None' }),
+      ];
+      const stream = new ArrayLexerStream(tokens);
+
+      const rule = rules.COMLINK_NONE_LITERAL;
+
+      expect(rule.tryMatch(stream)).toBeAMatch(
+        tesMatch(
+          {
+            kind: 'ComlinkNoneLiteral',
+          },
+          tokens[0]
+        )
+      );
+    });
+
     it('should parse object literal', () => {
       const tokens: ReadonlyArray<LexerToken> = [
         tesTok({ kind: LexerTokenKind.SEPARATOR, separator: '{' }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,10 +566,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@superfaceai/ast@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-1.2.0.tgz#f41823d550e0b0a05a8398be22a68b7b3912dde3"
-  integrity sha512-HMmdSUNzKuVgQ9g9YS/eiv3/CitSZks8eury8sAi2QbwT+n5f9SsVcmHxL2/QbkRCmlPpRqHJ6YSCqvBZ2fu1g==
+"@superfaceai/ast@1.3.0-rc.0":
+  version "1.3.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-1.3.0-rc.0.tgz#0c20d706fc8f03edf250959ef4db67d1102098e2"
+  integrity sha512-dIlKiRV4Kc23uiGfPhnoCfosOxhZT+G789xXgc9w8qWJiF9mSvrE8MKai+Zmhd54U7o6ZasP7EpbLF2NpN4vtA==
   dependencies:
     ajv "^8.8.2"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

Adds parsing for `NoneLiteral`.

Requires https://github.com/superfaceai/ast-js/pull/99

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
