### PR TITLE
Condition to add SingleLineCommentTrivia to terminal tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Profile header rule now strictly requires full semver version in version field, as the spec defines
+- Condition to add SingleLineCommentTrivia to termina tokens in sublexer
 
 ## [2.0.0] - 2022-11-08
 ### Added

--- a/src/language/lexer/sublexer/jessie/expression.ts
+++ b/src/language/lexer/sublexer/jessie/expression.ts
@@ -864,7 +864,7 @@ function resolveTerminationTokens(
 
   // Tokens that are always terminator tokens
   // What isn't included here is the ts.SyntaxKind.EndOfFileToken token - this token is hardcoded into the scanner because it ignores nesting
-  if (!(ts.SyntaxKind.SingleLineCommentTrivia in termTokens)) {
+  if (!termTokens.includes(ts.SyntaxKind.SingleLineCommentTrivia)) {
     termTokens.push(ts.SyntaxKind.SingleLineCommentTrivia);
   }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

Fixes condition, checking it `SingleLineCommentTrivia` is already present in terminal tokens.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This caused that oneline comments in Jessie script were included in single line expressions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
